### PR TITLE
Scale file encoding detection for large files

### DIFF
--- a/tests/data_import/test_csvmeta.py
+++ b/tests/data_import/test_csvmeta.py
@@ -8,10 +8,13 @@ from data_import import utils
 def test_alter_uploadedfile_raises_exception(mocker):
     mock_uploadedfile = mocker.MagicMock(spec=UploadedFile)
 
+    # Return a generator from file.chunks() so init doesn't fail.
+    mock_uploadedfile.chunks.return_value = iter(['foo'])
+
     # Patch _field_names setter to avoid StopIteration as result of
     # passing in mock (e.g., empty) file
-
     mocker.patch.object(utils.CsvMeta, '_field_names')
+    mocker.patch.object(utils.CsvMeta, '_file_encoding')
 
     meta = utils.CsvMeta(mock_uploadedfile)
 


### PR DESCRIPTION
Previously, we only considered the first chunk of file content to determine file encoding. This was not sufficient for large files. Do small refactors to facilitate iterating over all file chunks until an encoding is detected.