### PR TITLE
Calculate percentiles within like unit groups

### DIFF
--- a/payroll/models.py
+++ b/payroll/models.py
@@ -56,6 +56,11 @@ class Employer(SluggedModel, VintagedModel):
         return bool(self.parent)
 
     @property
+    def is_unclassified(self):
+        return (self.is_department and not self.universe) \
+            or (not self.is_department and not self.taxonomy)
+
+    @property
     def endpoint(self):
         if self.is_department:
             return 'department'

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -85,7 +85,7 @@ class EmployerView(DetailView):
         return results['median']
 
     def expenditure_percentile(self):
-        if self.object.is_department is True:
+        if any([self.object.is_department, self.object.is_unclassified]):
             return 'N/A'
 
         query = '''
@@ -131,7 +131,7 @@ class EmployerView(DetailView):
         return result[0] * 100
 
     def salary_percentile(self):
-        if self.object.is_department is True:
+        if any([self.object.is_department, self.object.is_unclassified]):
             return 'N/A'
 
         query = '''


### PR DESCRIPTION
This PR:

- Calculates expenditure and median salary percentile within the given unit's taxonomy, if the unit is classified.
- Returns "N/A" is the unit is unclassified.

A note: One we implement #147, I think it would be more appropriate to make these calculations to properties of the `Unit` model.