### PR TITLE
Add queries for comparative department percentiles

### DIFF
--- a/templates/department.html
+++ b/templates/department.html
@@ -18,6 +18,10 @@
   </div>
   {% endif %}
 
+  <div class="badge badge-secondary">
+    {{ entity.parent.taxonomy }}
+  </div>
+
   <div class="row mb-4">
     {% with context = aggregate_stats %}
       {% include 'partials/baseball_stats.html' %}
@@ -28,9 +32,9 @@
     <div id="intro-text" class="col-lg-6">
       <p>This department makes up <strong>{{ percent_of_total_expenditure|format_percentile }}</strong> of the total payroll expenditure of <strong>{{ entity.parent }}</strong>.</p>
 
-      <p>This department's total expenditure is higher than <strong>{{ expenditure_percentile|format_percentile }}</strong> of other <strong>{{ entity.universe }}s</strong>.</p>
+      <p>This department's total expenditure is higher than <strong>{{ expenditure_percentile|format_percentile }}</strong> of other <strong>{{ entity.parent.taxonomy }} {{ entity.universe }}s</strong>.</p>
 
-      <p>This department's median salary is higher than <strong>{{ salary_percentile|format_percentile }}</strong> of other <strong>{{ entity.universe }}s</strong>.</p>
+      <p>This department's median salary is higher than <strong>{{ salary_percentile|format_percentile }}</strong> of other <strong>{{ entity.parent.taxonomy }} {{ entity.universe }}s</strong>.</p>
     </div>
     <div id="department-expenditure-chart" class="col-lg-6">strip plot of salaries in department</div>
   </div>

--- a/templates/unit.html
+++ b/templates/unit.html
@@ -12,9 +12,9 @@
 <div class="col-md-12">
   <h2 class="mb-3"><i class="fas fa-building"></i> {{ entity }}</h2>
   <div class="badge badge-primary">
-
     {{ entity.taxonomy }}
   </div>
+
   <div class="badge badge-secondary">
     {{ entity.size_class }}
   </div>


### PR DESCRIPTION
This PR:

- Moves the unit-level expenditure and salary percentile queries from `EmployerView` to `UnitView`.
- Adds department-level expenditure and salary percentile queries from to `DepartmentView`.
- Adds text describing these salaries to the department page.

<img width="1117" alt="screen shot 2018-07-12 at 3 03 56 pm" src="https://user-images.githubusercontent.com/12176173/42656411-d443d5a4-85e4-11e8-8706-d5275b17b63c.png">

The percentile queries are actually quite similar and I could see an enhancement where we refactor the common structure, etc., into a mixin or something, but I think that's outside of the scope of this 
PR.

Closes #121, closes #120 