### PR TITLE
Only display position title

### DIFF
--- a/templates/partials/person_table.html
+++ b/templates/partials/person_table.html
@@ -17,7 +17,7 @@
   {% for job in jobs %}
     <tr>
       <td><a href="{{ url('person', kwargs={'slug': job.person.slug}) }}">{{ job.person }}</a></td>
-      <td>{{ job.position }}</td>
+      <td>{{ job.position.title }}</td>
       {% if not entity.is_department and department_salaries %}
       <td><a href="{{ url('department', kwargs={'slug': job.position.employer.slug}) }}">{{ job.position.employer }}</a></td>
       {% endif %}

--- a/templates/person.html
+++ b/templates/person.html
@@ -32,7 +32,7 @@
             <h3 class="card-title mb-4">
               <i class="fas fa-list"></i> Summary
             </h3>
-            <p><strong>{{ entity }}</strong> earned <strong class="bg-warning">{{ current_salary|format_salary }}</strong> in {{ data_year }} as a <strong>{{ current_job.position }}</strong> for <strong><a href="{{ url(current_employer.endpoint, kwargs={"slug": current_employer.slug}) }}">{{ current_employer }}</a></strong>. {% if current_job.start_date %}{{ entity.last_name }} had worked in this position since <strong>{{ current_job.start_date.strftime('%B %d, %Y') }}</strong>.{% endif %}</p>
+            <p><strong>{{ entity }}</strong> earned <strong class="bg-warning">{{ current_salary|format_salary }}</strong> in {{ data_year }} as a <strong>{{ current_job.position.title }}</strong> for <strong><a href="{{ url(current_employer.endpoint, kwargs={"slug": current_employer.slug}) }}">{{ current_employer }}</a></strong>. {% if current_job.start_date %}{{ entity.last_name }} had worked in this position since <strong>{{ current_job.start_date.strftime('%B %d, %Y') }}</strong>.{% endif %}</p>
 
             <p>{{ entity.last_name }} earned more than <strong>{{ employer_percentile|format_percentile }}</strong> of employees in <strong><a href="{{ url(current_employer.endpoint, kwargs={"slug": current_employer.slug}) }}">{{ current_employer }}</a></strong>.</p>
 


### PR DESCRIPTION
Display the position title only in the templates. Retrain a longer `__str__` on the model for debugging purposes (titles alone are not very useful when you have a handle on an object). Closes #214.