### PR TITLE
Also cache search views

### DIFF
--- a/bga_database/settings.py
+++ b/bga_database/settings.py
@@ -34,7 +34,6 @@ INSTALLED_APPS = [
     'storages',
     'payroll',
     'data_import',
-    'debug_toolbar',
     'django.contrib.postgres',
     'postgres_stats',
 ]
@@ -48,7 +47,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
 ]
 

--- a/bga_database/urls.py
+++ b/bga_database/urls.py
@@ -30,7 +30,7 @@ urlpatterns = [
     path('department/<str:slug>/', cache_page(60 * 15)(payroll_views.DepartmentView.as_view()), name='department'),
     path('person/<str:slug>/', cache_page(60 * 15)(payroll_views.PersonView.as_view()), name='person'),
     path('entity-lookup/', payroll_views.EntityLookup.as_view(), name='entity-lookup'),
-    path('search/', payroll_views.SearchView.as_view(), name='search'),
+    path('search/', cache_page(60 * 15)(payroll_views.SearchView.as_view()), name='search'),
     path('<int:error_code>', payroll_views.error, name='error'),
 
     # admin


### PR DESCRIPTION
Turns out some of the search views seem to be taxing the production server. This caches them. And also removes the debug toolbar middleware (it was interacting strangely with the cache middleware).