### PR TITLE
Only cache the pages we want to cache

### DIFF
--- a/bga_database/settings.py
+++ b/bga_database/settings.py
@@ -40,7 +40,6 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -49,7 +48,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.cache.FetchFromCacheMiddleware',
 ]
 
 ROOT_URLCONF = 'bga_database.urls'

--- a/bga_database/urls.py
+++ b/bga_database/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 from django.conf import settings
 from django.contrib import admin
 from django.urls import path
-from django.views.decorators.cache import cache_page, never_cache
+from django.views.decorators.cache import cache_page
 
 from data_import import views as import_views
 from payroll import views as payroll_views
@@ -40,7 +40,7 @@ urlpatterns = [
     path('flush-cache/<str:secret_key>', payroll_views.flush_cache, name='flush_cache'),
 
     # data import
-    path('data-import/', never_cache(import_views.Uploads.as_view()), name='data-import'),
+    path('data-import/', import_views.Uploads.as_view(), name='data-import'),
     path('data-import/upload-source-file/', import_views.SourceFileHook.as_view(), name='upload-source-file'),
     path('data-import/upload-standardized-file/', import_views.StandardizedDataUpload.as_view(), name='upload-standardized-file'),
     path('data-import/review/responding-agency/<int:s_file_id>', import_views.RespondingAgencyReview.as_view(), name='review-responding-agency'),


### PR DESCRIPTION
> According to the docs, if you use the caching middleware in your settings file, Django caches everything, regardless of anything you may have overridden downstream. 

thanks, @evz.