### PR TITLE
Revise distribution charts

### DIFF
--- a/bga_database/chart_settings.py
+++ b/bga_database/chart_settings.py
@@ -4,3 +4,5 @@ Define useful variables for chart styling applied in Python-land.
 
 BAR_DEFAULT = '#004c76'
 BAR_HIGHLIGHT = '#fff200'
+DISTRIBUTION_MAX = 200000
+DISTRIBUTION_BIN_NUM = 20

--- a/bga_database/static/js/chart_helper.js
+++ b/bga_database/static/js/chart_helper.js
@@ -29,15 +29,18 @@ var ChartHelper = {
             var edges = data[this.value];
 
             if (this.value === data.length) {
-              edges = data[this.value - 1];
-              return '$' + edges.upper_edge;
-            }
-
-            // Occurs when Highcharts wants to add an extra label
-            try {
-              return '$' + edges.lower_edge;
-            } catch (err) {
-              return '';
+                // Don't show the last label
+                return null;
+            } else if (this.value === data.length - 1) {
+                // Add a plus to the last visible label
+                return '$' + edges.lower_edge + '+';
+            } else {
+                try {
+                    return '$' + edges.lower_edge;
+                } catch (err) {
+                    // Occurs when Highcharts wants to add an extra label
+                    return '';
+                }
             }
         };
 
@@ -77,7 +80,6 @@ var ChartHelper = {
                     formatter: axis_format,
                 },
                 tickInterval: 0,
-                endOnTick: true,
                 title: {
                     text: 'Salary range',
                 },

--- a/bga_database/static/js/chart_helper.js
+++ b/bga_database/static/js/chart_helper.js
@@ -26,14 +26,31 @@ var ChartHelper = {
         };
 
         var axis_format = function() {
-            var edges = data[this.value];
+            var penultimate_bin = this.value === data.length - 1;
+            var last_bin = this.value === data.length;
 
-            if (this.value === data.length) {
-                // Don't show the last label
-                return null;
-            } else if (this.value === data.length - 1) {
-                // Add a plus to the last visible label
-                return '$' + edges.lower_edge + '+';
+            var edges;
+
+            if ( last_bin ) {
+                edges = data[this.value - 1];
+            } else {
+                edges = data[this.value];
+            }
+
+            var composite_last_bin = edges.upper_edge !== '200k';
+
+            if ( last_bin ) {
+                if ( composite_last_bin ) {
+                    return null;
+                } else {
+                    return '$' + edges.upper_edge;
+                }
+            } else if ( penultimate_bin ) {
+                if ( composite_last_bin ) {
+                    return '$' + edges.lower_edge + '+';
+                } else {
+                    return '$' + edges.lower_edge;
+                }
             } else {
                 try {
                     return '$' + edges.lower_edge;
@@ -43,6 +60,16 @@ var ChartHelper = {
                 }
             }
         };
+
+        // Hide the last tick, if the chart includes a column for 200k+, i.e.,
+        // the last tick is not "200k"
+        var end_on_tick;
+
+        if ( data[data.length - 1].upper_edge !== '200k' ) {
+            end_on_tick = false;
+        } else {
+            end_on_tick = true;
+        }
 
         var element = entity_type + '-distribution-chart';
 
@@ -80,6 +107,7 @@ var ChartHelper = {
                     formatter: axis_format,
                 },
                 tickInterval: 0,
+                endOnTick: end_on_tick,
                 title: {
                     text: 'Salary range',
                 },

--- a/payroll/charts.py
+++ b/payroll/charts.py
@@ -1,5 +1,3 @@
-import math
-
 import numpy as np
 
 from bga_database.chart_settings import BAR_DEFAULT

--- a/payroll/charts.py
+++ b/payroll/charts.py
@@ -12,17 +12,12 @@ class ChartHelperMixin(object):
 
     def bin_salary_data(self, data):
         float_data = np.asarray(data, dtype='float')
-
-        # Size of the bins
-        multiplier = 25000
-
-        # This is to make the appropriate number of bins
         max_value = np.amax(float_data)
-        bin_num = math.ceil(max_value / multiplier)  # rounding up to capture max value
-        bin_edges = np.array([], dtype='float')
 
-        for i in range(bin_num + 1):  # adding 1 to get appropriate number of bins
-            bin_edges = np.append(bin_edges, i * multiplier)
+        bin_size = 10000
+        bin_num = 20
+        bin_edges = np.array([i * bin_size for i in range(bin_num + 1)], dtype='float')
+        bin_edges = np.append(bin_edges, max_value)
 
         values, edges = np.histogram(float_data, bins=bin_edges)
 

--- a/payroll/charts.py
+++ b/payroll/charts.py
@@ -1,20 +1,27 @@
 import numpy as np
 
-from bga_database.chart_settings import BAR_DEFAULT
+from bga_database.chart_settings import BAR_DEFAULT, DISTRIBUTION_MAX, \
+    DISTRIBUTION_BIN_NUM
 from payroll.utils import format_ballpark_number
 
 
 class ChartHelperMixin(object):
     def _get_bar_color(self, lower_edge, upper_edge):
+        if lower_edge == DISTRIBUTION_MAX:
+            return 'url(#highcharts-default-pattern-0)'
         return BAR_DEFAULT
 
     def bin_salary_data(self, data):
         float_data = np.asarray(data, dtype='float')
         max_value = np.amax(float_data)
 
-        bin_size = 10000
-        bin_num = 20
-        bin_edges = np.array([i * bin_size for i in range(bin_num + 1)], dtype='float')
+        bin_size = DISTRIBUTION_MAX / DISTRIBUTION_BIN_NUM
+
+        bin_edges = np.array(
+            [i * bin_size for i in range(DISTRIBUTION_BIN_NUM + 1)],
+            dtype='float'
+        )
+
         if max_value > bin_edges[-1]:
             bin_edges = np.append(bin_edges, max_value)
 

--- a/payroll/charts.py
+++ b/payroll/charts.py
@@ -17,7 +17,8 @@ class ChartHelperMixin(object):
         bin_size = 10000
         bin_num = 20
         bin_edges = np.array([i * bin_size for i in range(bin_num + 1)], dtype='float')
-        bin_edges = np.append(bin_edges, max_value)
+        if max_value > bin_edges[-1]:
+            bin_edges = np.append(bin_edges, max_value)
 
         values, edges = np.histogram(float_data, bins=bin_edges)
 

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -468,10 +468,10 @@ class PersonView(DetailView, ChartHelperMixin):
     template_name = 'person.html'
 
     def _get_bar_color(self, lower, upper):
-        if lower < self.salary_amount < upper:
+        if lower < int(self.salary_amount) <= upper:
             return BAR_HIGHLIGHT
         else:
-            return BAR_DEFAULT
+            return super()._get_bar_color(lower, upper)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -10,7 +10,7 @@ from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
 from postgres_stats.aggregates import Percentile
 
-from bga_database.chart_settings import BAR_DEFAULT, BAR_HIGHLIGHT
+from bga_database.chart_settings import BAR_HIGHLIGHT
 from payroll.charts import ChartHelperMixin
 from payroll.models import Job, Person, Salary, Unit, Department
 from payroll.search import PayrollSearchMixin, FacetingMixin, \

--- a/templates/base.html
+++ b/templates/base.html
@@ -135,7 +135,7 @@
     <script src="{{ static('js/lib/bootstrap.min.js') }}"></script>
     <script src="{{ static('js/lib/fontawesome-all.min.js') }}"></script>
     <script src="{{ static('js/lib/highcharts.src.js') }}"></script>
-    <script src="https://code.highcharts.com/modules/pattern-fill.js"></script>
+    <script src="{{ static('js/lib/pattern-fill.js') }}"></script>
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-18960172-1"></script>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -135,6 +135,7 @@
     <script src="{{ static('js/lib/bootstrap.min.js') }}"></script>
     <script src="{{ static('js/lib/fontawesome-all.min.js') }}"></script>
     <script src="{{ static('js/lib/highcharts.src.js') }}"></script>
+    <script src="https://code.highcharts.com/modules/pattern-fill.js"></script>
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-18960172-1"></script>
 


### PR DESCRIPTION
this pr adds a composite bin for all salaries exceeding 200k to the distribution chart, so that wide distributions do not produce un-useful charts. closes #306.

### overall distribution
<img width="975" alt="screen shot 2019-01-16 at 3 23 32 pm" src="https://user-images.githubusercontent.com/12176173/51279336-b98e0700-19a2-11e9-8411-ad9fa00163f0.png">

### chicago
<img width="529" alt="screen shot 2019-01-16 at 3 23 11 pm" src="https://user-images.githubusercontent.com/12176173/51279337-b98e0700-19a2-11e9-8ae5-f12b7afb2934.png">

### orland park
(no salaries above 200k)
<img width="542" alt="screen shot 2019-01-16 at 3 22 39 pm" src="https://user-images.githubusercontent.com/12176173/51279338-b98e0700-19a2-11e9-8702-9df9bd09eb2f.png">
