### PR TITLE
Signup and login refinements

### DIFF
--- a/bga_database/jinja2.py
+++ b/bga_database/jinja2.py
@@ -1,5 +1,6 @@
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.urls import reverse
+from django.contrib import messages
 
 from jinja2 import Environment
 
@@ -15,6 +16,7 @@ def environment(**options):
     env.globals.update({
         'static': staticfiles_storage.url,
         'url': reverse,
+        'get_messages': messages.get_messages,
     })
 
     env.filters.update({

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -648,13 +648,13 @@ class UserLoginView(LoginView):
             response['redirect_url'] = context['next']
             user = context['form'].get_user()
             messages.add_message(self.request,
-                                messages.INFO,
-                                'Welcome back {}!'.format(user.first_name),
-                                extra_tags='font-weight-bold')
+                                 messages.INFO,
+                                 'Welcome back {}!'.format(user.first_name),
+                                 extra_tags='font-weight-bold')
 
             messages.add_message(self.request,
-                                messages.INFO,
-                                "We've logged you in so you can continue using the database.")
+                                 messages.INFO,
+                                 "We've logged you in so you can continue using the database.")
 
         return JsonResponse(response)
 

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -15,6 +15,7 @@ from django.contrib.auth.views import LoginView, PasswordResetView, \
 from django.contrib.auth import login as auth_login
 from django.conf import settings
 from django.urls import reverse_lazy
+from django.contrib import messages
 
 from bga_database.chart_settings import BAR_DEFAULT, BAR_HIGHLIGHT
 from payroll.charts import ChartHelperMixin
@@ -645,6 +646,15 @@ class UserLoginView(LoginView):
             response['errors'] = errors['__all__']
         else:
             response['redirect_url'] = context['next']
+            user = context['form'].get_user()
+            messages.add_message(self.request,
+                                messages.INFO,
+                                'Welcome back {}!'.format(user.first_name),
+                                extra_tags='font-weight-bold')
+
+            messages.add_message(self.request,
+                                messages.INFO,
+                                "We've logged you in so you can continue using the database.")
 
         return JsonResponse(response)
 
@@ -672,6 +682,15 @@ class UserSignupView(FormView):
             response['errors'] = errors
         else:
             response['redirect_url'] = self.request.POST['next']
+
+        messages.add_message(self.request,
+                             messages.INFO,
+                             'Thanks for signing up!',
+                             extra_tags='font-weight-bold')
+
+        messages.add_message(self.request,
+                             messages.INFO,
+                             'Use the your email address and the password you just created to login next time you visit.')
 
         return JsonResponse(response)
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -75,6 +75,14 @@
           <li class="nav-item">
             <a class="nav-link" href="/user-guide/"><i class="fas fa-question fa-fw"></i> User Guide</a>
           </li>
+          {% if request.user.is_authenticated %}
+          <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" id="user-dropdown" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fas fa-user fa-fw"></i> Welcome back {{ request.user.first_name }}!</a>
+              <div class="dropdown-menu" aria-labelledby="user-dropdown">
+                <a class="dropdown-item" href="/logout/">Logout</a>
+              </div>
+          </li>
+          {% endif %}
         </ul>
       </div>
     </nav>

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -103,7 +103,7 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-body">
-                <h3>If you'd like to keep using this free resource, please sign-up with your email address.</h3>
+                <h3>If you'd like to keep using this free resource, please create an account.</h3>
                 <p>We'll send you our latest investigations every week.</p>
                 <form class="form" id="signup-form">
                     <input type="hidden" value="{{ csrf_token }}" name="csrfmiddlewaretoken" />
@@ -181,6 +181,25 @@
         </div>
     </div>
 </div>
+{% if get_messages(request) %}
+    <div class="modal" tabindex="-1" role="dialog" id="messageModal">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-body">
+                    <h3>You're all set!</h3>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                    <p>
+                    {% for message in get_messages(request) %}
+                        <span class="{{ message.tags }}">{{ message }} </span>
+                    {% endfor %}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endif %}
 {% endblock %}
 
 {% block extra_js %}
@@ -238,7 +257,9 @@
     {% else %}
         initSearch({{ request.GET.dict()|safe }});
     {% endif %}
-
+    {% if get_messages(request) %}
+        $('#messageModal').modal()
+    {% endif %}
     $('[id*="facet-toggle"]').click(function toggleClick(e) {
         // On click, content has not yet been expanded, i.e., if aria-expanded
         // is false, the element is about to be expanded, so we need to update


### PR DESCRIPTION
Had a conversation with Starlyn and this is what we came up with to address her concern that it was not super clear that users were creating an account when they signed up. In this PR I:

* Reworded the signup form to make it clearer what was happening
* Added confirmation modals that appear after signup and login that let the user know they are now logged in
* Added an item to the top nav bar that makes it clear site-wide that users are logged in 
* Added a logout button as a dropdown from the above item