### PR TITLE
Only add signup message when signup really occurs

### DIFF
--- a/payroll/views.py
+++ b/payroll/views.py
@@ -686,13 +686,13 @@ class UserSignupView(FormView):
             response['redirect_url'] = self.request.POST['next']
 
             messages.add_message(self.request,
-                                messages.INFO,
-                                'Thanks for signing up!',
-                                extra_tags='font-weight-bold')
+                                 messages.INFO,
+                                 'Thanks for signing up!',
+                                 extra_tags='font-weight-bold')
 
             messages.add_message(self.request,
-                                messages.INFO,
-                                'Use the your email address and the password you just created to login next time you visit.')
+                                 messages.INFO,
+                                 'Use the your email address and the password you just created to login next time you visit.')
 
         return JsonResponse(response)
 

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -646,7 +646,9 @@ class UserLoginView(LoginView):
             response['errors'] = errors['__all__']
         else:
             response['redirect_url'] = context['next']
+
             user = context['form'].get_user()
+
             messages.add_message(self.request,
                                  messages.INFO,
                                  'Welcome back {}!'.format(user.first_name),
@@ -683,14 +685,14 @@ class UserSignupView(FormView):
         else:
             response['redirect_url'] = self.request.POST['next']
 
-        messages.add_message(self.request,
-                             messages.INFO,
-                             'Thanks for signing up!',
-                             extra_tags='font-weight-bold')
+            messages.add_message(self.request,
+                                messages.INFO,
+                                'Thanks for signing up!',
+                                extra_tags='font-weight-bold')
 
-        messages.add_message(self.request,
-                             messages.INFO,
-                             'Use the your email address and the password you just created to login next time you visit.')
+            messages.add_message(self.request,
+                                messages.INFO,
+                                'Use the your email address and the password you just created to login next time you visit.')
 
         return JsonResponse(response)
 


### PR DESCRIPTION
When a user tried to signup when they already had an account and then went to login, they got the message for logging in as well as the message for signing up. This fixes that so they only get the message associated with the appropriate action.