### PR TITLE
Expand startup documentation, pin kombu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR /app
 # for building lean and efficient containers:
 # https://blog.realkinetic.com/building-minimal-docker-containers-for-python-applications-37d0272c52f3
 COPY ./requirements.txt /app/requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
 # Copy the contents of the current host directory (i.e., our app code) into
 # the container.

--- a/README.md
+++ b/README.md
@@ -31,11 +31,32 @@ Perform the following steps from your terminal.
     `docker-compose.yml`, run `docker-compose logs -f <SERVICE_NAME>`, e.g.,
     `docker-compose logs -f app`.
 
-3. The application will work without data, but if you're like to add some,
+3. The application will work without data, but if you'd like to add some,
 first make a formatted data file.
 
     ```bash
-    docker-compose exec app make 2016-formatted.csv
+    docker-compose exec app make 2017-actual-pt-1.csv
     ```
 
-    Next, go to http://localhost:8000/data-import/ and follow the steps to upload the CSV you just made. Don't forget to put in the data year. It will take a bit to complete each step. You can refresh the page to see if it's ready to move on to the next section. You can also keep track of progress in your worker terminal by running `docker-compose logs -f app worker`.
+    This will process `data/raw/2017-payroll-actual-pt-1.csv` into a file called `2017-actual-pt-1.csv`. To preview the processed data in your
+    terminal, run:
+
+    ```bash
+    docker-compose exec head 2017-actual-pt-1.csv | csvlook --no-inference | less
+    ```
+
+    Type `-S` then hit Enter or Return to trim long lines, then use the arrow keys to scroll up, down, left, or right.
+
+4. Next, create a superuser, so you can log into the data import interface.
+
+    ```bash
+    docker-compose exec app python manage.py createsuperuser
+    ```
+
+5. Finally, go to http://localhost:8000/data-import/ and follow the steps to upload the CSV you just made. Don't forget to put in the data year!
+
+    It will take a bit to complete each step of the data import. You can refresh the page to see if it's ready to move on to the next section. (The status will have changed.) You can also keep track of progress in your worker terminal by running:
+
+    ```bash
+    docker-compose logs -f app worker
+    ```

--- a/README.md
+++ b/README.md
@@ -58,5 +58,5 @@ first make a formatted data file.
     It will take a bit to complete each step of the data import. You can refresh the page to see if it's ready to move on to the next section. (The status will have changed.) You can also keep track of progress in your worker terminal by running:
 
     ```bash
-    docker-compose logs -f app worker
+    docker-compose logs -f worker
     ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ redis>=2.10.5,<3
 saferedisqueue==3.0.0
 pysolr==3.7.0
 sentry-sdk==0.5.1
+kombu==4.3.0
 
 pytest==3.4.1
 attrs==19.1.0


### PR DESCRIPTION
This pull request expands startup documentation somewhat. It also pins the `kombu` dependency, so Celery continues to work. See https://github.com/pydanny/cookiecutter-django/issues/1954.