### PR TITLE
Upgrade Django and Jinja, patch Redis tests for local development

### DIFF
--- a/bga_database/local_settings.py.example
+++ b/bga_database/local_settings.py.example
@@ -1,3 +1,6 @@
+import os
+
+
 # This should be False in production!
 DEBUG = True
 
@@ -20,10 +23,11 @@ AWS_STORAGE_BUCKET_NAME = '<bucket_name>'
 AWS_ACCESS_KEY_ID = '<key>'
 AWS_SECRET_ACCESS_KEY = '<secret>'
 
+REDIS_HOST = os.getenv('REDIS_HOST', 'redis')
 REDIS_PORT = 6379
 REDIS_DB = 0
-REDIS_FMT = 'redis://redis:{port}/{db}'
-REDIS_URL = REDIS_FMT.format(port=REDIS_PORT, db=REDIS_DB)
+REDIS_FMT = 'redis://{host}:{port}/{db}'
+REDIS_URL = REDIS_FMT.format(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB)
 
 CELERY_BROKER_URL = REDIS_URL
 CELERY_ACCEPT_CONTENT = ['json']

--- a/configs/local_settings.py.travis
+++ b/configs/local_settings.py.travis
@@ -20,10 +20,11 @@ AWS_STORAGE_BUCKET_NAME = '<bucket_name>'
 AWS_ACCESS_KEY_ID = '<key>'
 AWS_SECRET_ACCESS_KEY = '<secret>'
 
+REDIS_HOST = 'localhost'
 REDIS_PORT = 6379
 REDIS_DB = 0
-REDIS_FMT = 'redis://localhost:{port}/{db}'
-REDIS_URL = REDIS_FMT.format(port=REDIS_PORT, db=REDIS_DB)
+REDIS_FMT = 'redis://{host}:{port}/{db}'
+REDIS_URL = REDIS_FMT.format(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB)
 
 CELERY_BROKER_URL = REDIS_URL
 CELERY_ACCEPT_CONTENT = ['json']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_started
     volumes:
       # Mount the development directory as a volume into the container, so
       # Docker automatically recognizes your changes.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.0.2
+Django==2.2
 psycopg2-binary==2.7.4
 numpy==1.14.1
 csvkit==1.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.2
+Django==2.2.9
 psycopg2-binary==2.7.4
 numpy==1.14.1
 csvkit==1.0.3
@@ -6,7 +6,7 @@ cchardet==2.1.1
 census==0.8.7
 us==1.0.0
 inflect==1.0.1
-jinja2==2.10
+jinja2==2.10.1
 lxml==4.2.1
 django-debug-toolbar==1.9.1
 django-storages==1.6.5

--- a/tests/data_import/conftest.py
+++ b/tests/data_import/conftest.py
@@ -105,7 +105,7 @@ def queue_teardown(request):
     @request.addfinalizer
     def flush_queue():
         from redis import Redis
-        from bga_database.settings import REDIS_PORT
+        from django.conf import settings
 
-        r = Redis(port=REDIS_PORT)
-        r.flushdb()
+        queue = Redis(host=settings.REDIS_HOST, port=settings.REDIS_PORT)
+        queue.flushdb()


### PR DESCRIPTION
## Description

This PR:

- Upgrades Django and Jinja2 to the recommended versions for security reasons, and also to take advantage of new features in Django 2.2, specifically database constraints
- Updates Redis config values so tests pass locally, as well as in CI 

## Testing instructions

- Confirm the tests pass in CI.
- Rebuild your application container: `docker-compose build app`.
- Run the tests locally: `docker-compose -f docker-compose.yml -f tests/docker-compose.yml pytest -sv`. Confirm they pass.
- Cruise around the local app and confirm that views look and behave as expected.