### PR TITLE
resolve charting error for units with no depts

### DIFF
--- a/templates/unit.html
+++ b/templates/unit.html
@@ -109,7 +109,12 @@
 
 <script type="text/javascript">
   ChartHelper.make_salary_chart({{ employee_salary_json|safe }}, 'employee');
-  ChartHelper.make_composition_chart({{ composition_json|safe }});
   ChartHelper.make_payroll_expenditure_chart({{ payroll_expenditure|safe }});
 </script>
+{% if department_salaries %}
+<script type="text/javascript">
+  ChartHelper.make_composition_chart({{ composition_json|safe }});
+</script>
+{% endif %}
+
 {% endblock %}


### PR DESCRIPTION
### Overview
This PR makes a small change to resolve a Highcharts error that occurred with Units that have no department children. 

Closes #380 