### PR TITLE
Adjust a handful of queries to consider total pay

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -97,7 +97,7 @@
 
     <div class="row mb-3">
       <div class="col-md">
-        <h5>Distribution of public salaries in 2017</h5>
+        <h5>Distribution of public salaries in {{ data_year }}</h5>
       </div>
     </div>
 


### PR DESCRIPTION
## Description

As I was fixing the queries to select data for the distribution charts on the homepage and employer pages, I noticed there are a handful of queries where we're using salary amount to calculate values. Since it's a boring change and you already figured out the logic, I went ahead and updated them all to use total pay instead.

## Testing instructions

- Check out this branch and run the application.
- Navigate to a few pages and be sure no exceptions are raised.