### PR TITLE
Emp chart enhancements

### DIFF
--- a/bga_database/static/js/chart_helper.js
+++ b/bga_database/static/js/chart_helper.js
@@ -143,8 +143,8 @@ var ChartHelper = {
         type: 'bar'
       },
       tooltip: {
-        formatter() {
-          return `${this.series.name}`
+        formatter: function() {
+          return this.series.name;
         }
       },
       legend: {
@@ -187,8 +187,8 @@ var ChartHelper = {
         text: ''
       },
       tooltip: {
-        formatter() {
-          return `${this.key}: $${this.y}`
+        formatter: function() {
+          return this.key + ": $" +  this.y;
         }
       },
       plotOptions: {

--- a/bga_database/static/js/chart_helper.js
+++ b/bga_database/static/js/chart_helper.js
@@ -142,7 +142,7 @@ var ChartHelper = {
       chart: {
         type: 'bar'
       },
-      colors: ['#387fc6', '#578ecd', '#8baddc', '#a5bde3', '#d2ddf1', '#e8eef8'],
+      colors: ['#0B2F42', '#004C76', '#245D8C', '#538BC2', '#82BEED', '#758892'],
       xAxis: {
         labels: {
           enabled: false
@@ -172,7 +172,7 @@ var ChartHelper = {
       chart: {
         type: 'pie'
       },
-      colors: ['#387fc6', '#739dd6'],
+      colors: ['#004C76', '#538BC2'],
       title: {
         text: ''
       },

--- a/bga_database/static/js/chart_helper.js
+++ b/bga_database/static/js/chart_helper.js
@@ -152,14 +152,17 @@ var ChartHelper = {
         verticalAlign: 'top',
         y: 30
       },
-      colors: ['#0B2F42', '#004C76', '#245D8C', '#538BC2', '#82BEED', '#758892'],
+      colors: ['#0B2F42', '#023f62', '#245D8C', '#538BC2', '#82BEED', '#758892'],
       xAxis: {
         labels: {
           enabled: false
         }
       },
       yAxis: {
-        reversedStacks: false
+        reversedStacks: false,
+        title: {
+          text: 'Percent of total unit payroll expenditure'
+        }
       },
       plotOptions: {
         series: {
@@ -188,7 +191,7 @@ var ChartHelper = {
       },
       tooltip: {
         formatter: function() {
-          return this.key + ": $" +  this.y;
+          return this.key + ": $" +  this.y.toLocaleString();
         }
       },
       plotOptions: {

--- a/bga_database/static/js/chart_helper.js
+++ b/bga_database/static/js/chart_helper.js
@@ -142,7 +142,12 @@ var ChartHelper = {
       chart: {
         type: 'bar'
       },
-      colors: ['#004c76', '#c84747', '#fd0', '#67488b', '#1a9b5b', '#343a40'],
+      colors: ['#387fc6', '#578ecd', '#8baddc', '#a5bde3', '#d2ddf1', '#e8eef8'],
+      xAxis: {
+        labels: {
+          enabled: false
+        }
+      },
       yAxis: {
         reversedStacks: false
       },
@@ -167,6 +172,7 @@ var ChartHelper = {
       chart: {
         type: 'pie'
       },
+      colors: ['#387fc6', '#739dd6'],
       title: {
         text: ''
       },

--- a/bga_database/static/js/chart_helper.js
+++ b/bga_database/static/js/chart_helper.js
@@ -142,6 +142,16 @@ var ChartHelper = {
       chart: {
         type: 'bar'
       },
+      tooltip: {
+        formatter() {
+          return `${this.series.name}`
+        }
+      },
+      legend: {
+        floating: true,
+        verticalAlign: 'top',
+        y: 30
+      },
       colors: ['#0B2F42', '#004C76', '#245D8C', '#538BC2', '#82BEED', '#758892'],
       xAxis: {
         labels: {
@@ -175,6 +185,11 @@ var ChartHelper = {
       colors: ['#004C76', '#538BC2'],
       title: {
         text: ''
+      },
+      tooltip: {
+        formatter() {
+          return `${this.key}: $${this.y}`
+        }
       },
       plotOptions: {
         series: {

--- a/templates/partials/payroll_expenditure.html
+++ b/templates/partials/payroll_expenditure.html
@@ -1,6 +1,6 @@
 <div class="card-body">
-  <h4 class="card-subtitle">Payroll expenditure breakout</h4>
-  <h4 class="card-subtitle"><small class="text-muted">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+  <h4 class="card-subtitle mt-3">Payroll expenditure breakout</h4>
+  <h4 class="card-subtitle mb-3"><small class="text-muted">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
   tempor incididunt ut labore et dolore magna aliqua.</small></h4>
   <div class="row">
     <div id="payroll-expenditure-chart" class="col-lg-6"></div>

--- a/templates/partials/payroll_expenditure.html
+++ b/templates/partials/payroll_expenditure.html
@@ -1,5 +1,7 @@
 <div class="card-body">
-  <h4 class="card-subtitle">Payroll Expenditure Breakout</h4>
+  <h4 class="card-subtitle">Payroll expenditure breakout</h4>
+  <h4 class="card-subtitle"><small class="text-muted">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+  tempor incididunt ut labore et dolore magna aliqua.</small></h4>
   <div class="row">
     <div id="payroll-expenditure-chart" class="col-lg-6"></div>
     <div class="col-lg-6">

--- a/templates/unit.html
+++ b/templates/unit.html
@@ -96,7 +96,11 @@
   <div class="col-md">
     <div class="card mb-4">
       {% include 'partials/department_card.html' %}
-      <div id="department-composition-chart"></div>
+      <div class="card-body">
+        <h4 class="card-subtitle">Top-spending departments as a proportion of total expenditure</h4>
+        <h4 class="card-subtitle"><small class="text-muted">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</small></h4>
+        <div id="department-composition-chart"></div>
+      </div>
     </div>
   </div>
 </div>

--- a/templates/unit.html
+++ b/templates/unit.html
@@ -97,8 +97,8 @@
     <div class="card mb-4">
       {% include 'partials/department_card.html' %}
       <div class="card-body">
-        <h4 class="card-subtitle">Top-spending departments as a proportion of total expenditure</h4>
-        <h4 class="card-subtitle"><small class="text-muted">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</small></h4>
+        <h4 class="card-subtitle mt-3">Top-spending departments as a proportion of total expenditure</h4>
+        <h4 class="card-subtitle mb-3"><small class="text-muted">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</small></h4>
         <div id="department-composition-chart"></div>
       </div>
     </div>


### PR DESCRIPTION
### Overview
This PR adds a bit more coherent and useful styling to the pay breakout chart and top spending departments chart. 

Closes #390 

### Notes
- Any feedback on the color scheme for the top spending depts chart is appreciated. FYI, from left to right, the 2, 4, and 6th colors are colors taken directly from the page.
- I had a thought to add a tooltip feature for the composition chart that shows the name of the department rather than a percentage amount. Let me know if you think it's useful or redundant.