### PR TITLE
Data import admin

### DIFF
--- a/bga_database/urls.py
+++ b/bga_database/urls.py
@@ -45,7 +45,6 @@ urlpatterns = [
     # data import
     path('data-import/', import_views.Uploads.as_view(), name='data-import'),
     path('data-import/upload-source-file/', import_views.SourceFileHook.as_view(), name='upload-source-file'),
-    # path('data-import/upload-standardized-file/', import_views.StandardizedDataUpload.as_view(), name='upload-standardized-file'),
     path('data-import/review/responding-agency/<int:s_file_id>', import_views.RespondingAgencyReview.as_view(), name='review-responding-agency'),
     path('data-import/review/parent-employer/<int:s_file_id>', import_views.ParentEmployerReview.as_view(), name='review-parent-employer'),
     path('data-import/review/child-employer/<int:s_file_id>', import_views.ChildEmployerReview.as_view(), name='review-child-employer'),

--- a/bga_database/urls.py
+++ b/bga_database/urls.py
@@ -45,7 +45,7 @@ urlpatterns = [
     # data import
     path('data-import/', import_views.Uploads.as_view(), name='data-import'),
     path('data-import/upload-source-file/', import_views.SourceFileHook.as_view(), name='upload-source-file'),
-    path('data-import/upload-standardized-file/', import_views.StandardizedDataUpload.as_view(), name='upload-standardized-file'),
+    # path('data-import/upload-standardized-file/', import_views.StandardizedDataUpload.as_view(), name='upload-standardized-file'),
     path('data-import/review/responding-agency/<int:s_file_id>', import_views.RespondingAgencyReview.as_view(), name='review-responding-agency'),
     path('data-import/review/parent-employer/<int:s_file_id>', import_views.ParentEmployerReview.as_view(), name='review-parent-employer'),
     path('data-import/review/child-employer/<int:s_file_id>', import_views.ChildEmployerReview.as_view(), name='review-child-employer'),

--- a/data_import/admin.py
+++ b/data_import/admin.py
@@ -66,11 +66,12 @@ class AdminSourceFile(admin.ModelAdmin):
 class AdminStandardizedFile(admin.ModelAdmin):
     form = UploadForm
 
-    # def save_model(request, obj, form, change):
-        # import pdb
-        # pdb.set_trace()
-        # create Upload object
-        # s_file.copy_to_database()
+    def save_model(self, request, obj, form, change):
+        upload = Upload.objects.create()
+        obj.upload = upload
+        import pdb
+        pdb.set_trace()
+        obj.copy_to_database()
 
 admin.site.register(SourceFile, AdminSourceFile)
 admin.site.register(RespondingAgency, AdminRespondingAgency)

--- a/data_import/admin.py
+++ b/data_import/admin.py
@@ -68,18 +68,16 @@ class AdminStandardizedFile(admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         upload = Upload.objects.create()
+        standardized_file = form.cleaned_data['standardized_file']
+        reporting_year = form.cleaned_data['reporting_year']
 
-        uploaded_file = form.cleaned_data['standardized_file']
+        obj.upload = upload
+        obj.standardized_file = standardized_file
+        obj.reporting_year = reporting_year
 
-        s_file_meta = {
-            'standardized_file': uploaded_file,
-            'upload': upload,
-            'reporting_year': form.cleaned_data['reporting_year'],
-        }
+        obj.copy_to_database()
 
-        s_file = StandardizedFile.objects.create(**s_file_meta)
-
-        s_file.copy_to_database()
+        super().save_model(request, obj, form, change)
 
 
 admin.site.register(SourceFile, AdminSourceFile)

--- a/data_import/admin.py
+++ b/data_import/admin.py
@@ -68,12 +68,20 @@ class AdminStandardizedFile(admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         upload = Upload.objects.create()
-        obj.upload = upload
-        import pdb
-        pdb.set_trace()
-        obj.copy_to_database()
+
+        uploaded_file = form.cleaned_data['standardized_file']
+
+        s_file_meta = {
+            'standardized_file': uploaded_file,
+            'upload': upload,
+            'reporting_year': form.cleaned_data['reporting_year'],
+        }
+
+        s_file = StandardizedFile.objects.create(**s_file_meta)
+
+        s_file.copy_to_database()
+
 
 admin.site.register(SourceFile, AdminSourceFile)
 admin.site.register(RespondingAgency, AdminRespondingAgency)
 admin.site.register(StandardizedFile, AdminStandardizedFile)
-

--- a/data_import/admin.py
+++ b/data_import/admin.py
@@ -3,6 +3,7 @@ import datetime
 from django.contrib import admin
 
 from data_import.models import SourceFile, Upload, RespondingAgency, StandardizedFile
+from data_import.forms import UploadForm
 
 
 class AdminRespondingAgency(admin.ModelAdmin):
@@ -63,7 +64,13 @@ class AdminSourceFile(admin.ModelAdmin):
 
 
 class AdminStandardizedFile(admin.ModelAdmin):
-    pass  
+    form = UploadForm
+
+    # def save_model(request, obj, form, change):
+        # import pdb
+        # pdb.set_trace()
+        # create Upload object
+        # s_file.copy_to_database()
 
 admin.site.register(SourceFile, AdminSourceFile)
 admin.site.register(RespondingAgency, AdminRespondingAgency)

--- a/data_import/admin.py
+++ b/data_import/admin.py
@@ -68,16 +68,9 @@ class AdminStandardizedFile(admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         upload = Upload.objects.create()
-        standardized_file = form.cleaned_data['standardized_file']
-        reporting_year = form.cleaned_data['reporting_year']
-
         obj.upload = upload
-        obj.standardized_file = standardized_file
-        obj.reporting_year = reporting_year
-
-        obj.copy_to_database()
-
         super().save_model(request, obj, form, change)
+        obj.copy_to_database()
 
 
 admin.site.register(SourceFile, AdminSourceFile)

--- a/data_import/admin.py
+++ b/data_import/admin.py
@@ -2,7 +2,7 @@ import datetime
 
 from django.contrib import admin
 
-from data_import.models import SourceFile, Upload, RespondingAgency
+from data_import.models import SourceFile, Upload, RespondingAgency, StandardizedFile
 
 
 class AdminRespondingAgency(admin.ModelAdmin):
@@ -62,5 +62,10 @@ class AdminSourceFile(admin.ModelAdmin):
         super().save_model(request, obj, form, change)
 
 
+class AdminStandardizedFile(admin.ModelAdmin):
+    pass  
+
 admin.site.register(SourceFile, AdminSourceFile)
 admin.site.register(RespondingAgency, AdminRespondingAgency)
+admin.site.register(StandardizedFile, AdminStandardizedFile)
+

--- a/data_import/forms.py
+++ b/data_import/forms.py
@@ -37,6 +37,9 @@ class UploadForm(LoginRequiredMixin, forms.ModelForm):
         self._validate_filetype(meta.file_type)
         self._validate_fields(meta.field_names)
 
+        now = datetime.datetime.now().strftime('%Y-%m-%dT%H%M%S')
+        s_file.name = '{}-{}'.format(now, s_file.name)
+
         return s_file
 
     def clean_reporting_year(self):
@@ -46,10 +49,3 @@ class UploadForm(LoginRequiredMixin, forms.ModelForm):
             raise forms.ValidationError('Reporting year cannot exceed the current year')
 
         return reporting_year
-
-    def form_valid(self, form):
-        uploaded_file = form.cleaned_data['standardized_file']
-        now = datetime.datetime.now().strftime('%Y-%m-%dT%H%M%S')
-        uploaded_file.name = '{}-{}'.format(now, uploaded_file.name)
-
-        return super().form_valid(form)

--- a/data_import/forms.py
+++ b/data_import/forms.py
@@ -1,12 +1,14 @@
 import datetime
 
 from django import forms
+from django.contrib.auth.mixins import LoginRequiredMixin
 
 from data_import.models import StandardizedFile
 from data_import.utils import CsvMeta
 
 
-class UploadForm(forms.ModelForm):
+
+class UploadForm(LoginRequiredMixin, forms.ModelForm):
     class Meta:
         model = StandardizedFile
         fields = []
@@ -19,9 +21,6 @@ class UploadForm(forms.ModelForm):
 
     def _validate_fields(self, incoming_fields):
         missing_fields = ', '.join(set(CsvMeta.REQUIRED_FIELDS) - set(incoming_fields))
-
-        import pdb
-        pdb.set_trace()
 
         if missing_fields:
             message = 'Standardized file missing fields: {}'.format(missing_fields)

--- a/data_import/forms.py
+++ b/data_import/forms.py
@@ -20,6 +20,9 @@ class UploadForm(forms.ModelForm):
     def _validate_fields(self, incoming_fields):
         missing_fields = ', '.join(set(CsvMeta.REQUIRED_FIELDS) - set(incoming_fields))
 
+        import pdb
+        pdb.set_trace()
+
         if missing_fields:
             message = 'Standardized file missing fields: {}'.format(missing_fields)
             raise forms.ValidationError(message)

--- a/data_import/forms.py
+++ b/data_import/forms.py
@@ -2,10 +2,15 @@ import datetime
 
 from django import forms
 
+from data_import.models import StandardizedFile
 from data_import.utils import CsvMeta
 
 
-class UploadForm(forms.Form):
+class UploadForm(forms.ModelForm):
+    class Meta:
+        model = StandardizedFile
+        fields = []
+
     '''
     Collect standardized data.
     '''
@@ -40,3 +45,18 @@ class UploadForm(forms.Form):
             raise forms.ValidationError('Reporting year cannot exceed the current year')
 
         return reporting_year
+
+    def form_valid(self, form):
+        uploaded_file = form.cleaned_data['standardized_file']
+        now = datetime.datetime.now().strftime('%Y-%m-%dT%H%M%S')
+        uploaded_file.name = '{}-{}'.format(now, uploaded_file.name)
+
+        s_file_meta = {
+            'standardized_file': uploaded_file,
+            'upload': upload,
+            'reporting_year': form.cleaned_data['reporting_year'],
+        }
+
+        s_file = StandardizedFile.objects.create(**s_file_meta)
+
+        return super().form_valid(form)

--- a/data_import/forms.py
+++ b/data_import/forms.py
@@ -7,7 +7,6 @@ from data_import.models import StandardizedFile
 from data_import.utils import CsvMeta
 
 
-
 class UploadForm(LoginRequiredMixin, forms.ModelForm):
     class Meta:
         model = StandardizedFile
@@ -52,13 +51,5 @@ class UploadForm(LoginRequiredMixin, forms.ModelForm):
         uploaded_file = form.cleaned_data['standardized_file']
         now = datetime.datetime.now().strftime('%Y-%m-%dT%H%M%S')
         uploaded_file.name = '{}-{}'.format(now, uploaded_file.name)
-
-        s_file_meta = {
-            'standardized_file': uploaded_file,
-            'upload': upload,
-            'reporting_year': form.cleaned_data['reporting_year'],
-        }
-
-        s_file = StandardizedFile.objects.create(**s_file_meta)
 
         return super().form_valid(form)

--- a/data_import/views.py
+++ b/data_import/views.py
@@ -10,7 +10,7 @@ from django.views import View
 from django.views.generic import DetailView, ListView
 from django.views.generic.edit import FormView
 
-from data_import.forms import UploadForm
+# from data_import.forms import UploadForm
 from data_import.models import SourceFile, StandardizedFile, RespondingAgency, \
     Upload
 from data_import.utils import ChildEmployerQueue, ParentEmployerQueue, \
@@ -59,29 +59,29 @@ class SourceFileHook(View):
         return file_metadata
 
 
-class StandardizedDataUpload(LoginRequiredMixin, FormView):
-    template_name = 'data_import/upload.html'
-    form_class = UploadForm
-    success_url = '/data-import/'
+# class StandardizedDataUpload(LoginRequiredMixin, FormView):
+#     template_name = 'data_import/upload.html'
+#     form_class = UploadForm
+#     success_url = '/data-import/'
 
-    def form_valid(self, form):
-        upload = Upload.objects.create()
+#     def form_valid(self, form):
+#         upload = Upload.objects.create()
 
-        uploaded_file = form.cleaned_data['standardized_file']
-        now = datetime.datetime.now().strftime('%Y-%m-%dT%H%M%S')
-        uploaded_file.name = '{}-{}'.format(now, uploaded_file.name)
+#         uploaded_file = form.cleaned_data['standardized_file']
+#         now = datetime.datetime.now().strftime('%Y-%m-%dT%H%M%S')
+#         uploaded_file.name = '{}-{}'.format(now, uploaded_file.name)
 
-        s_file_meta = {
-            'standardized_file': uploaded_file,
-            'upload': upload,
-            'reporting_year': form.cleaned_data['reporting_year'],
-        }
+#         s_file_meta = {
+#             'standardized_file': uploaded_file,
+#             'upload': upload,
+#             'reporting_year': form.cleaned_data['reporting_year'],
+#         }
 
-        s_file = StandardizedFile.objects.create(**s_file_meta)
+#         s_file = StandardizedFile.objects.create(**s_file_meta)
 
-        s_file.copy_to_database()
+#         s_file.copy_to_database()
 
-        return super().form_valid(form)
+#         return super().form_valid(form)
 
 
 class Uploads(LoginRequiredMixin, ListView):

--- a/data_import/views.py
+++ b/data_import/views.py
@@ -59,31 +59,6 @@ class SourceFileHook(View):
         return file_metadata
 
 
-# class StandardizedDataUpload(LoginRequiredMixin, FormView):
-#     template_name = 'data_import/upload.html'
-#     form_class = UploadForm
-#     success_url = '/data-import/'
-
-#     def form_valid(self, form):
-#         upload = Upload.objects.create()
-
-#         uploaded_file = form.cleaned_data['standardized_file']
-#         now = datetime.datetime.now().strftime('%Y-%m-%dT%H%M%S')
-#         uploaded_file.name = '{}-{}'.format(now, uploaded_file.name)
-
-#         s_file_meta = {
-#             'standardized_file': uploaded_file,
-#             'upload': upload,
-#             'reporting_year': form.cleaned_data['reporting_year'],
-#         }
-
-#         s_file = StandardizedFile.objects.create(**s_file_meta)
-
-#         s_file.copy_to_database()
-
-#         return super().form_valid(form)
-
-
 class Uploads(LoginRequiredMixin, ListView):
     '''
     Index of data import. Display a list of standardized uploads,

--- a/data_import/views.py
+++ b/data_import/views.py
@@ -9,7 +9,6 @@ from django.urls import reverse
 from django.views import View
 from django.views.generic import DetailView, ListView
 
-# from data_import.forms import UploadForm
 from data_import.models import SourceFile, StandardizedFile, RespondingAgency, \
     Upload
 from data_import.utils import ChildEmployerQueue, ParentEmployerQueue, \

--- a/data_import/views.py
+++ b/data_import/views.py
@@ -8,7 +8,6 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.views import View
 from django.views.generic import DetailView, ListView
-from django.views.generic.edit import FormView
 
 # from data_import.forms import UploadForm
 from data_import.models import SourceFile, StandardizedFile, RespondingAgency, \

--- a/templates/data_import/index.html
+++ b/templates/data_import/index.html
@@ -19,7 +19,7 @@ Uploads
 
     <h2>
       Uploads
-      <a role="button" class="btn btn-outline-primary float-right" href="/data-import/upload-standardized-file/">
+      <a role="button" class="btn btn-outline-primary float-right" href="/admin/data_import/standardizedfile/add/">
         <i class="fa fa-fw fa-upload"></i> Upload
       </a>
     </h2>

--- a/tests/data_import/test_upload.py
+++ b/tests/data_import/test_upload.py
@@ -27,7 +27,11 @@ def test_missing_fields_raises_exception(standardized_data_upload_blob,
 
     mock_file = standardized_data_upload_blob['standardized_file']
 
-    rv = admin_client.post(reverse('upload-standardized-file'),
+    # rv = admin_client.post(reverse('upload-standardized-file'),
+    #                        data=standardized_data_upload_blob,
+    #                        files={'standardized_file': mock_file})
+
+    rv = admin_client.post('/admin/',
                            data=standardized_data_upload_blob,
                            files={'standardized_file': mock_file})
 

--- a/tests/data_import/test_upload.py
+++ b/tests/data_import/test_upload.py
@@ -1,6 +1,5 @@
 import datetime
 
-from django.urls import reverse
 import pytest
 
 from data_import.utils import CsvMeta
@@ -27,11 +26,7 @@ def test_missing_fields_raises_exception(standardized_data_upload_blob,
 
     mock_file = standardized_data_upload_blob['standardized_file']
 
-    # rv = admin_client.post(reverse('upload-standardized-file'),
-    #                        data=standardized_data_upload_blob,
-    #                        files={'standardized_file': mock_file})
-
-    rv = admin_client.post('/admin/',
+    rv = admin_client.post('/admin/data_import/standardizedfile/add/',
                            data=standardized_data_upload_blob,
                            files={'standardized_file': mock_file})
 
@@ -49,7 +44,7 @@ def test_non_csv_raises_exception(standardized_data_upload_blob,
 
     standardized_data_upload_blob['standardized_file'] = mock_file
 
-    rv = admin_client.post(reverse('upload-standardized-file'),
+    rv = admin_client.post('/admin/data_import/standardizedfile/add/',
                            data=standardized_data_upload_blob,
                            files={'standardized_file': mock_file})
 
@@ -67,7 +62,7 @@ def test_future_date_raises_exception(standardized_data_upload_blob,
 
     mock_file = standardized_data_upload_blob['standardized_file']
 
-    rv = admin_client.post(reverse('upload-standardized-file'),
+    rv = admin_client.post('/admin/data_import/standardizedfile/add/',
                            data=standardized_data_upload_blob,
                            files={'standardized_file': mock_file})
 
@@ -87,7 +82,7 @@ def test_valid_standardized_data_upload(standardized_data_upload_blob,
 
     standardized_data_upload_blob['standardized_file'] = real_file
 
-    rv = admin_client.post(reverse('upload-standardized-file'),
+    rv = admin_client.post('/admin/data_import/standardizedfile/add/',
                            data=standardized_data_upload_blob,
                            files={'standardized_file': real_file})
 


### PR DESCRIPTION
### Overview
This PR situates the data-import form in the django admin interface.

Closes #402 

### Notes:
I've been focusing my testing on the `test_upload` tests, they're failing because the urls are still set up to point toward `views.py`. My understanding is they should point toward the `/admin/` url