### PR TITLE
Reported pay wording

### DIFF
--- a/payroll/views.py
+++ b/payroll/views.py
@@ -83,11 +83,11 @@ class EmployerView(DetailView, ChartHelperMixin):
             'series_data': {
                 'Name': 'Data',
                 'data': [{
-                    'name': 'Base Pay',
+                    'name': 'Reported Base Pay',
                     'y': base_pay,
                     'label': 'base_pay',
                 }, {
-                    'name': 'Extra Pay',
+                    'name': 'Reported Extra Pay',
                     'y': extra_pay,
                     'label': 'extra_pay',
                 }],

--- a/templates/partials/payroll_expenditure.html
+++ b/templates/partials/payroll_expenditure.html
@@ -22,6 +22,7 @@
           {% endif %}
           <small class="text-muted">Median Extra Pay</small></br>
         </div>
+        <small class="text-muted">Calculated based on agency reporting. Some agencies did not report extra pay.</small>
       </div>
     </div>
   </div>

--- a/templates/partials/payroll_expenditure.html
+++ b/templates/partials/payroll_expenditure.html
@@ -18,7 +18,7 @@
           {% if median_ep %}
             <h4>{{ median_ep|format_salary }}</h4>
           {% else %}
-            <h4>Not available</h4>
+            <h4>Not reported</h4>
           {% endif %}
           <small class="text-muted">Median Extra Pay</small></br>
         </div>

--- a/templates/partials/person_table.html
+++ b/templates/partials/person_table.html
@@ -26,7 +26,7 @@
         {% if salary.amount %}
           {{ salary.amount|format_salary }}
         {% else %}
-          Not available
+          Not reported
         {% endif %}
         {% if current_salary %}
           {% if current_salary < salary.amount %}
@@ -43,7 +43,7 @@
         {% if salary.extra_pay %}
           {{ salary.extra_pay|format_salary }}
         {% else %}
-          Not available
+          Not reported
         {% endif %}
       </td>
       {% if show_start_date %}


### PR DESCRIPTION
### Overview
This pull request makes minor changes to copy around how agencies report extra pay in the recently added card for payroll breakout as well as for table changes around separating base and extra pay

Closes #408 and #409 

### Notes
Upon checking different pages to make sure the copy had been updated appropriately, I noticed that the clicking on a person's link resulted in an error: "Job matching query does not exist."