### PR TITLE
Create entity metadata API

### DIFF
--- a/bga_database/settings.py
+++ b/bga_database/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'postgres_stats',
     'debug_toolbar',
     'salsa_auth',
+    'rest_framework',
 ]
 
 MIDDLEWARE = [

--- a/bga_database/settings.py
+++ b/bga_database/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 import os
 
 from .local_settings import *  # noqa
+from .chart_settings import *  # noqa
 
 
 ALLOWED_HOSTS = [

--- a/bga_database/urls.py
+++ b/bga_database/urls.py
@@ -29,6 +29,7 @@ router = routers.DefaultRouter()
 router.register(r'index', api_views.IndexViewSet, 'index')
 router.register(r'units', api_views.UnitViewSet)
 router.register(r'departments', api_views.DepartmentViewSet)
+router.register(r'people', api_views.PersonViewSet)
 
 EIGHT_HOURS = 60 * 60 * 8
 

--- a/bga_database/urls.py
+++ b/bga_database/urls.py
@@ -21,6 +21,14 @@ from django.views.decorators.cache import cache_page
 from data_import import views as import_views
 from payroll import views as payroll_views
 
+from rest_framework import routers
+from payroll import api as api_views
+
+
+router = routers.DefaultRouter()
+router.register(r'index', api_views.IndexViewSet, 'index')
+router.register(r'units', api_views.UnitViewSet)
+router.register(r'departments', api_views.DepartmentViewSet)
 
 EIGHT_HOURS = 60 * 60 * 8
 
@@ -52,6 +60,10 @@ urlpatterns = [
     path('data-import/add/', import_views.review, name='add-entity'),
 ]
 
+urlpatterns += [
+    path('', include(router.urls)),
+    path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+]
 
 if settings.DEBUG:
     from django.conf.urls import include, url

--- a/payroll/api.py
+++ b/payroll/api.py
@@ -46,6 +46,7 @@ class DepartmentViewSet(ReadOnlyModelViewSetWithDataYear):
     serializer_class = serializers.DepartmentSerializer
     queryset = Department.objects.all()
 
+
 class PersonViewSet(ReadOnlyModelViewSetWithDataYear):
     serializer_class = serializers.PersonSerializer
     queryset = Person.objects.all()

--- a/payroll/api.py
+++ b/payroll/api.py
@@ -1,7 +1,7 @@
 from rest_framework import viewsets
 from rest_framework.response import Response
 
-from payroll.models import Unit, Department
+from payroll.models import Unit, Department, Person
 from payroll import serializers
 
 
@@ -24,6 +24,8 @@ class IndexViewSet(viewsets.ViewSet):
 
 class ReadOnlyModelViewSetWithDataYear(viewsets.ReadOnlyModelViewSet):
 
+    lookup_field = 'slug'
+
     def retrieve(self, request, slug=None):
         try:
             data_year = request.query_params['data_year']
@@ -37,11 +39,13 @@ class ReadOnlyModelViewSetWithDataYear(viewsets.ReadOnlyModelViewSet):
 
 class UnitViewSet(ReadOnlyModelViewSetWithDataYear):
     serializer_class = serializers.UnitSerializer
-    lookup_field = 'slug'
     queryset = Unit.objects.all()
 
 
 class DepartmentViewSet(ReadOnlyModelViewSetWithDataYear):
     serializer_class = serializers.DepartmentSerializer
-    lookup_field = 'slug'
     queryset = Department.objects.all()
+
+class PersonViewSet(ReadOnlyModelViewSetWithDataYear):
+    serializer_class = serializers.PersonSerializer
+    queryset = Person.objects.all()

--- a/payroll/api.py
+++ b/payroll/api.py
@@ -1,0 +1,48 @@
+from rest_framework import viewsets
+from rest_framework.response import Response
+
+from payroll.models import Unit, Department
+from payroll import serializers
+
+
+class IndexViewSet(viewsets.ViewSet):
+    serializer_class = serializers.IndexSerializer
+
+    def list(self, request):
+        '''
+        TODO: Should this be retrieve? Want to keep API consistent across Index
+        and entity-related views.
+        '''
+        try:
+            data_year = request.query_params['data_year']
+        except KeyError:
+            return Response({})
+        else:
+            serializer = serializers.IndexSerializer(instance=data_year)
+            return Response(serializer.data)
+
+
+class ReadOnlyModelViewSetWithDataYear(viewsets.ReadOnlyModelViewSet):
+
+    def retreive(self, request, pk=None):
+        print('Subclass retrieve called')
+        try:
+            data_year = request.query_params['data_year']
+        except KeyError:
+            return Response({})
+        else:
+            serializer = self.serializer_class(instance=self.get_object(),
+                                               context={'data_year': data_year})
+            return Response(serializer.data)
+
+
+class UnitViewSet(ReadOnlyModelViewSetWithDataYear):
+    serializer_class = serializers.UnitSerializer
+    lookup_field = 'slug'
+    queryset = Unit.objects.all()
+
+
+class DepartmentViewSet(ReadOnlyModelViewSetWithDataYear):
+    serializer_class = serializers.DepartmentSerializer
+    lookup_field = 'slug'
+    queryset = Department.objects.all()

--- a/payroll/api.py
+++ b/payroll/api.py
@@ -24,8 +24,7 @@ class IndexViewSet(viewsets.ViewSet):
 
 class ReadOnlyModelViewSetWithDataYear(viewsets.ReadOnlyModelViewSet):
 
-    def retreive(self, request, pk=None):
-        print('Subclass retrieve called')
+    def retrieve(self, request, slug=None):
         try:
             data_year = request.query_params['data_year']
         except KeyError:

--- a/payroll/charts.py
+++ b/payroll/charts.py
@@ -6,12 +6,12 @@ from payroll.utils import format_ballpark_number
 
 
 class ChartHelperMixin(object):
-    def _get_bar_color(self, lower_edge, upper_edge):
+    def _get_bar_color(self, lower_edge, upper_edge, **kwargs):
         if lower_edge == DISTRIBUTION_MAX:
             return 'url(#highcharts-default-pattern-0)'
         return BAR_DEFAULT
 
-    def bin_salary_data(self, data):
+    def bin_salary_data(self, data, **kwargs):
         float_data = np.asarray(data, dtype='float')
         max_value = np.amax(float_data)
 
@@ -36,7 +36,7 @@ class ChartHelperMixin(object):
                 'value': int(value),  # number of salaries in given bin
                 'lower_edge': format_ballpark_number(lower),
                 'upper_edge': format_ballpark_number(upper),
-                'color': self._get_bar_color(lower, upper),
+                'color': self._get_bar_color(lower, upper, **kwargs),
             })
 
         return salary_json

--- a/payroll/charts.py
+++ b/payroll/charts.py
@@ -40,3 +40,21 @@ class ChartHelperMixin(object):
             })
 
         return salary_json
+
+    def _make_pie_chart(self, container, base_pay, extra_pay):
+        return {
+            'container': container,
+            'total_pay': base_pay + extra_pay,
+            'series_data': {
+                'Name': 'Data',
+                'data': [{
+                    'name': 'Reported Base Pay',
+                    'y': base_pay,
+                    'label': 'base_pay',
+                }, {
+                    'name': 'Reported Extra Pay',
+                    'y': extra_pay,
+                    'label': 'extra_pay',
+                }],
+            },
+        }

--- a/payroll/charts.py
+++ b/payroll/charts.py
@@ -40,21 +40,3 @@ class ChartHelperMixin(object):
             })
 
         return salary_json
-
-    def _make_pie_chart(self, container, base_pay, extra_pay):
-        return {
-            'container': container,
-            'total_pay': base_pay + extra_pay,
-            'series_data': {
-                'Name': 'Data',
-                'data': [{
-                    'name': 'Reported Base Pay',
-                    'y': base_pay,
-                    'label': 'base_pay',
-                }, {
-                    'name': 'Reported Extra Pay',
-                    'y': extra_pay,
-                    'label': 'extra_pay',
-                }],
-            },
-        }

--- a/payroll/models.py
+++ b/payroll/models.py
@@ -1,4 +1,4 @@
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.db import models, connection
 from django.db.models import Q, CheckConstraint, UniqueConstraint
 from django.utils.translation import gettext_lazy as _
@@ -26,7 +26,10 @@ class SourceFileMixin(object):
     removed from the unit.
     '''
     def source_file(self, year):
-        responding_agency = self.responding_agency(year)
+        try:
+            responding_agency = self.responding_agency(year)
+        except ObjectDoesNotExist:
+            return None
 
         try:
             source_file = responding_agency.source_files\
@@ -34,7 +37,7 @@ class SourceFileMixin(object):
                                            .source_file
 
         except SourceFile.DoesNotExist:
-            source_file = None
+            return None
 
         return source_file
 

--- a/payroll/serializers.py
+++ b/payroll/serializers.py
@@ -1,0 +1,393 @@
+from django.db import connection
+from django.db.models import Q, FloatField, Sum
+from django.db.models.functions import Coalesce, NullIf
+from postgres_stats.aggregates import Percentile
+from rest_framework import serializers
+
+from payroll.models import Employer, Unit, Department, Salary
+from payroll.charts import ChartHelperMixin
+
+
+# /v1/index/YEAR
+class IndexSerializer(serializers.Serializer, ChartHelperMixin):
+
+    salary_count = serializers.SerializerMethodField()
+    unit_count = serializers.SerializerMethodField()
+    department_count = serializers.SerializerMethodField()
+    salary_json = serializers.SerializerMethodField()
+
+    def get_salary_count(self, data_year):
+        return Salary.objects.filter(vintage__standardized_file__reporting_year=data_year).count()
+
+    def get_unit_count(self, data_year):
+        return Unit.objects.filter(vintage__standardized_file__reporting_year=data_year).count()
+
+    def get_department_count(self, data_year):
+        return Department.objects.filter(vintage__standardized_file__reporting_year=data_year).count()
+
+    def get_salary_json(self, data_year):
+        with connection.cursor() as cursor:
+            cursor.execute('''
+                SELECT
+                  COALESCE(amount, 0) + COALESCE(extra_pay, 0)
+                FROM payroll_salary AS salary
+                JOIN data_import_upload AS upload
+                ON salary.vintage_id = upload.id
+                JOIN data_import_standardizedfile AS file
+                ON upload.id = file.upload_id
+                WHERE file.reporting_year = {}
+            '''.format(data_year))
+
+            all_salaries = [x[0] for x in cursor]
+
+        try:
+            return self.bin_salary_data(all_salaries)
+
+        except ValueError:
+            if settings.DEBUG:
+                return []
+            raise
+
+
+class EmployerSerializer(serializers.ModelSerializer, ChartHelperMixin):
+
+    salaries = serializers.SerializerMethodField()
+    median_tp = serializers.SerializerMethodField()
+    median_bp = serializers.SerializerMethodField()
+    median_ep = serializers.SerializerMethodField()
+    headcount = serializers.SerializerMethodField()
+    total_expenditure = serializers.SerializerMethodField()
+    salary_percentile = serializers.SerializerMethodField()
+    expenditure_percentile = serializers.SerializerMethodField()
+    employee_salary_json = serializers.SerializerMethodField()
+    source_link = serializers.SerializerMethodField()
+    payroll_expenditure = serializers.SerializerMethodField()
+
+    @property
+    def employer_queryset(self):
+        return Employer.objects.filter(
+            Q(id=self.instance.id) | Q(parent_id=self.instance.id)
+        )
+
+    @property
+    def median_salaries(self):
+        if not hasattr(self, '_median_salaries'):
+            median_base_pay = Percentile(
+                'positions__jobs__salaries__amount', 0.5, output_field=FloatField()
+            )
+            median_extra_pay = Percentile(
+                'positions__jobs__salaries__extra_pay', 0.5, output_field=FloatField()
+            )
+            median_total_pay = Percentile(
+                (
+                    NullIf(
+                        Coalesce('positions__jobs__salaries__amount', 0) +
+                        Coalesce('positions__jobs__salaries__extra_pay', 0), 0
+                    )
+                ), 0.5, output_field=FloatField()
+            )
+
+            self._median_salaries = self.employer_queryset.aggregate(
+                median_base_pay=median_base_pay,
+                median_extra_pay=median_extra_pay,
+                median_total_pay=median_total_pay
+            )
+
+        return self._median_salaries
+
+    @property
+    def entity_payroll(self):
+        if not hasattr(self, '_entity_payroll'):
+            entity_base_pay = Sum(Coalesce("positions__jobs__salaries__amount", 0))
+            entity_extra_pay = Sum(Coalesce("positions__jobs__salaries__extra_pay", 0))
+
+            self._entity_payroll = self.employer_queryset.aggregate(
+                base_pay=entity_base_pay,
+                extra_pay=entity_extra_pay
+            )
+
+        return self._entity_payroll
+
+    def get_salaries(self, obj):
+        '''
+        TODO: Return attributes needed in template.
+        '''
+        return list(str(s) for s in Salary.of_employer(obj.id, n=5))
+
+    def get_median_tp(self, obj):
+        return self.median_salaries['median_total_pay']
+
+    def get_median_bp(self, obj):
+        return self.median_salaries['median_base_pay']
+
+    def get_median_ep(self, obj):
+        return self.median_salaries['median_extra_pay']
+
+    def get_headcount(self, obj):
+        return len(obj.employee_salaries)
+
+    def get_total_expenditure(self, obj):
+        return self.entity_payroll['base_pay'] + self.entity_payroll['extra_pay']
+
+    def get_salary_percentile(self, obj):
+        if obj.is_unclassified:
+            return 'N/A'
+
+        query = '''
+            WITH employer_parent_lookup AS (
+              SELECT
+                id,
+                COALESCE(parent_id, id) AS parent_id
+              FROM payroll_employer
+            ),
+            median_salaries_by_unit AS (
+              SELECT
+                percentile_cont(0.5) WITHIN GROUP (
+                  ORDER BY COALESCE(salary.amount, 0) + COALESCE(salary.extra_pay, 0) ASC
+                ) AS median_salary,
+                lookup.parent_id AS unit_id
+              FROM payroll_salary AS salary
+              JOIN payroll_job AS job
+              ON salary.job_id = job.id
+              JOIN payroll_position AS position
+              ON job.position_id = position.id
+              JOIN employer_parent_lookup AS lookup
+              ON position.employer_id = lookup.id
+              JOIN payroll_employer AS employer
+              ON lookup.parent_id = employer.id
+              WHERE employer.taxonomy_id = {taxonomy}
+              GROUP BY lookup.parent_id
+            ),
+            salary_percentiles AS (
+              SELECT
+                percent_rank() OVER (ORDER BY median_salary ASC) AS percentile,
+                unit_id
+              FROM median_salaries_by_unit
+            )
+            SELECT percentile
+            FROM salary_percentiles
+            WHERE unit_id = {id}
+            '''.format(taxonomy=obj.taxonomy.id,
+                       id=obj.id)
+
+        with connection.cursor() as cursor:
+            cursor.execute(query)
+            result = cursor.fetchone()
+
+        return result[0] * 100
+
+    def get_expenditure_percentile(self, obj):
+        if obj.is_unclassified:
+            return 'N/A'
+
+        query = '''
+            WITH employer_parent_lookup AS (
+              SELECT
+                id,
+                COALESCE(parent_id, id) AS parent_id
+              FROM payroll_employer
+            ),
+            expenditure_by_unit AS (
+              SELECT
+                SUM(COALESCE(salary.amount, 0) + COALESCE(salary.extra_pay, 0)) AS total_budget,
+                lookup.parent_id AS unit_id
+              FROM payroll_salary AS salary
+              JOIN payroll_job AS job
+              ON salary.job_id = job.id
+              JOIN payroll_position AS position
+              ON job.position_id = position.id
+              JOIN employer_parent_lookup AS lookup
+              ON position.employer_id = lookup.id
+              JOIN payroll_employer AS employer
+              ON lookup.parent_id = employer.id
+              WHERE employer.taxonomy_id = {taxonomy}
+              GROUP BY lookup.parent_id
+            ),
+            exp_percentiles AS (
+              SELECT
+                percent_rank() OVER (ORDER BY total_budget ASC) AS percentile,
+                unit_id
+              FROM expenditure_by_unit
+            )
+            SELECT
+              percentile
+            FROM exp_percentiles
+            WHERE unit_id = {id}
+        '''.format(taxonomy=obj.taxonomy.id,
+                   id=obj.id)
+
+        with connection.cursor() as cursor:
+            cursor.execute(query)
+            result = cursor.fetchone()
+
+        return result[0] * 100
+
+    def get_employee_salary_json(self, obj):
+        return self.bin_salary_data(obj.employee_salaries)
+
+    def get_source_link(self, obj):
+        return obj.source_file(2018)
+
+    def get_payroll_expenditure(self, obj):
+        return self._make_pie_chart('payroll-expenditure-chart',
+                                    self.entity_payroll['base_pay'],
+                                    self.entity_payroll['extra_pay'])
+
+
+# /v1/units/SLUG/YEAR
+class UnitSerializer(EmployerSerializer):
+
+    class Meta:
+        model = Unit
+        fields = '__all__'
+
+    department_salaries = serializers.SerializerMethodField()
+    population_percentile = serializers.SerializerMethodField()
+    highest_spending_department = serializers.SerializerMethodField()
+    composition_json = serializers.SerializerMethodField()
+
+    def get_department_salaries(self, obj):
+        pass
+
+    def get_population_percentile(self, obj):
+        if obj.get_population() is None:
+            return 'N/A'
+
+        query = '''
+            WITH pop_percentile AS (
+              SELECT
+                percent_rank() OVER (ORDER BY pop.population ASC) AS percentile,
+                pop.employer_id AS unit_id
+              FROM payroll_employerpopulation AS pop
+              JOIN payroll_employer AS emp
+              ON pop.employer_id = emp.id
+              JOIN payroll_employertaxonomy AS tax
+              ON emp.taxonomy_id = tax.id
+              WHERE tax.id = {taxonomy}
+            )
+            SELECT percentile FROM pop_percentile
+            WHERE unit_id = {id}
+        '''.format(taxonomy=obj.taxonomy_id, id=obj.id)
+
+        with connection.cursor() as cursor:
+            cursor.execute(query)
+            result = cursor.fetchone()
+
+        return result[0] * 100
+
+    def get_highest_spending_department(self, obj):
+        query = '''
+          WITH all_department_expenditures AS (
+            SELECT
+              SUM(COALESCE(salary.amount, 0) + COALESCE(salary.extra_pay, 0)) AS dept_budget,
+              employer.id as dept_id
+            FROM payroll_salary AS salary
+            JOIN payroll_job AS job
+            ON salary.job_id = job.id
+            JOIN payroll_position AS positions
+            ON job.position_id = positions.id
+            JOIN payroll_employer AS employer
+            ON positions.employer_id = employer.id
+            GROUP BY employer.id
+          ),
+          parent_department_expenditures AS (
+            SELECT
+              *
+            FROM all_department_expenditures as ade
+            JOIN payroll_employer AS employer
+            ON ade.dept_id = employer.id
+            WHERE employer.parent_id = {id}
+          )
+          SELECT
+            employer.name,
+            dept_budget,
+            employer.slug
+          FROM parent_department_expenditures
+          JOIN payroll_employer as employer
+          ON parent_department_expenditures.dept_id = employer.id
+          ORDER BY dept_budget DESC
+          LIMIT 1
+        '''.format(id=obj.id)
+
+        with connection.cursor() as cursor:
+            cursor.execute(query)
+            result = cursor.fetchone()
+
+        if result is None:
+            name, amount, slug = ['N/A'] * 3
+
+        else:
+            name, amount, slug = result
+
+        highest_spending_department = {
+            'name': name,
+            'amount': amount,
+            'slug': slug,
+        }
+
+        return highest_spending_department
+
+    def get_composition_json(self, obj):
+        pass
+
+
+# /v1/departments/SLUG/YEAR
+class DepartmentSerializer(EmployerSerializer):
+
+    class Meta:
+        model = Department
+        fields = '__all__'
+
+    percent_of_total_expenditure = serializers.SerializerMethodField()
+
+    def get_percent_of_total_expenditure(self, obj):
+        pass
+
+
+# /v1/people/SLUG/YEAR
+class PersonSerializer(serializers.ModelSerializer):
+
+    current_job = serializers.SerializerMethodField()
+    all_jobs = serializers.SerializerMethodField()
+    current_salary = serializers.SerializerMethodField()
+    current_employer = serializers.SerializerMethodField()
+    employer_type = serializers.SerializerMethodField()
+    employer_salary_json = serializers.SerializerMethodField()
+    employer_percentile = serializers.SerializerMethodField()
+    like_employer_percentile = serializers.SerializerMethodField()
+    salaries = serializers.SerializerMethodField()
+    source_link = serializers.SerializerMethodField()
+    noindex = serializers.SerializerMethodField()
+
+    def get_current_job(self, obj):
+        pass
+
+    def get_all_jobs(self, obj):
+        pass
+
+    def get_current_salary(self, obj):
+        pass
+
+    def get_current_employer(self, obj):
+        pass
+
+    def get_employer_type(self, obj):
+        pass
+
+    def get_employer_salary_json(self, obj):
+        pass
+
+    def get_employer_percentile(self, obj):
+        pass
+
+    def get_like_employer_percentile(self, obj):
+        pass
+
+    def get_salaries(self, obj):
+        pass
+
+    def get_source_link(self, obj):
+        pass
+
+    def get_noindex(self, obj):
+        pass

--- a/payroll/serializers.py
+++ b/payroll/serializers.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import connection
 from django.db.models import Q, FloatField, Sum, Count
 from django.db.models.functions import Coalesce, NullIf

--- a/payroll/serializers.py
+++ b/payroll/serializers.py
@@ -226,7 +226,7 @@ class EmployerSerializer(serializers.ModelSerializer, ChartHelperMixin):
         return self.bin_salary_data(obj.employee_salaries)
 
     def get_source_link(self, obj):
-        return obj.source_file(2018)
+        return obj.source_file(self.context['data_year'])
 
     def get_payroll_expenditure(self, obj):
         return self._make_pie_chart('payroll-expenditure-chart',

--- a/payroll/serializers.py
+++ b/payroll/serializers.py
@@ -246,7 +246,10 @@ class EmployerSerializer(serializers.ModelSerializer, ChartHelperMixin):
         )
 
     def get_source_link(self, obj):
-        return obj.source_file(self.context['data_year'])
+        source_file = obj.source_file(self.context['data_year'])
+
+        if source_file:
+            return source_file.url
 
     def get_payroll_expenditure(self, obj):
         return {
@@ -503,10 +506,10 @@ class PersonSerializer(serializers.ModelSerializer, ChartHelperMixin):
                              .order_by('-total_pay')
 
     def get_source_link(self, obj):
-        try:
-            obj.source_file(settings.DATA_YEAR)
-        except:
-            return None
+        source_file = obj.source_file(self.context['data_year'])
+
+        if source_file:
+            return source_file.url
 
     def get_noindex(self, obj):
         return self.person_current_salary.amount < 30000 or obj.noindex

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -575,12 +575,12 @@ class PersonView(DetailView, ChartHelperMixin):
         salary_data = current_job.position.employer.employee_salaries
         binned_salary_data = self.bin_salary_data(salary_data)
 
-        try:
-            source_file = self.object.source_file(settings.DATA_YEAR)
-        except:
-            source_link = None
-        else:
+        source_file = self.object.source_file(settings.DATA_YEAR)
+
+        if source_file:
             source_link = source_file.url
+        else:
+            source_link = None
 
         context.update({
             'data_year': settings.DATA_YEAR,

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -65,17 +65,6 @@ def error(request, error_code):
 class EmployerView(DetailView, ChartHelperMixin):
     context_object_name = 'entity'
 
-    # from_clause connects salaries and employers through a series of joins.
-    from_clause = '''
-        FROM payroll_job AS job
-        JOIN payroll_salary AS salary
-        ON salary.job_id = job.id
-        JOIN payroll_position AS position
-        ON job.position_id = position.id
-        JOIN payroll_employer as employer
-        ON position.employer_id = employer.id
-    '''
-
     def _make_pie_chart(self, container, base_pay, extra_pay):
         return {
             'container': container,

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -575,12 +575,12 @@ class PersonView(DetailView, ChartHelperMixin):
         salary_data = current_job.position.employer.employee_salaries
         binned_salary_data = self.bin_salary_data(salary_data)
 
-        source_file = self.object.source_file(settings.DATA_YEAR)
-
-        if source_file:
-            source_link = source_file.url
-        else:
+        try:
+            source_file = self.object.source_file(settings.DATA_YEAR)
+        except:
             source_link = None
+        else:
+            source_link = source_file.url
 
         context.update({
             'data_year': settings.DATA_YEAR,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django==2.2.9
+djangorestframework==3.11.0
 psycopg2-binary==2.7.4
 numpy==1.14.1
 csvkit==1.0.3


### PR DESCRIPTION
## Description

This PR installs [Django REST framework](https://www.django-rest-framework.org/#quickstart) and migrates calculations for display from view code to API endpoints for the index, units, and departments, and people.

The API expects a data year query parameter, however with the exception of the index endpoint and source file links, it does not yet use data year to filter calculations. This is so we can confirm the endpoints replicate the calculations from the views, before we add additional functionality in a separate PR.

Most of the diff in this PR is reorganizing code!

- All of the employer calculations are migrated verbatim from the view code, i.e., they don't need additional review. The only exception is grabbing salaries for an employer, which was migrated from the Salary model to a function on the Employer model in https://github.com/datamade/bga-payroll/commit/369c5dee3359d557513e65c42483bea4f8697750.
- Most of the person calculations were also migrated verbatim, except that the API returns total pay for current salary, instead of base pay.

## Test instructions

- Shut down any running containers: `docker-compose down`
- Build the application container to install the new dependency: `docker-compose build app`.
- Run the app: `docker-compose up -d`.
- Assuming your local instance has data, navigate to any unit page. Copy the slug from the URL.
- In a separate tab, navigate to `http://localhost:8000/units/SLUG/?data_year=2018`. Confirm that the data is returned without error, and that it matches what is displayed on the unit page.
- Repeat the above two steps for a department and a person, using the following endpoints:
  - `http://localhost:8000/departments/SLUG/?data_year=2018`
  - `http://localhost:8000/people/SLUG/?data_year=2018`
    - Note that `current_salary` is base pay in the view, but total pay in the API.