### PR TITLE
Reduce memory consumption during Person indexing

### DIFF
--- a/payroll/management/commands/build_solr_index.py
+++ b/payroll/management/commands/build_solr_index.py
@@ -347,10 +347,9 @@ class Command(BaseCommand):
                 documents.append(document)
 
                 if len(documents) == self.chunksize:
-                    self.stdout.write('Indexed {}'.format(self.chunksize))
-                    self.searcher.add(documents)
                     document_count += len(documents)
                     documents = []
+                    self.stdout.write('Indexed {}'.format(document_count))
 
         if documents:
             self.searcher.add(documents)

--- a/payroll/management/commands/build_solr_index.py
+++ b/payroll/management/commands/build_solr_index.py
@@ -338,13 +338,16 @@ class Command(BaseCommand):
         documents = []
         document_count = 0
 
-        people = Person.objects.all()
+        people = Person.objects.filter(
+            jobs__vintage__standardized_file__reporting_year__in=self.reporting_years
+        ).iterator()
 
         for person in people:
             for document in self._make_person_index(person):
                 documents.append(document)
 
                 if len(documents) == self.chunksize:
+                    self.stdout.write('Indexed {}'.format(self.chunksize))
                     self.searcher.add(documents)
                     document_count += len(documents)
                     documents = []


### PR DESCRIPTION
## Description

This PR makes the following changes to the Person indexing operation:

- Use [QuerySet.iterator()](https://docs.djangoproject.com/en/dev/ref/models/querysets/#iterator) to iterate over Person objects
- Only iterate over people with jobs in the given reporting years 