### PR TITLE
Correctly retrieve the most recent Salary on person pages, deduplicate autosuggestions

### DIFF
--- a/payroll/serializers.py
+++ b/payroll/serializers.py
@@ -615,7 +615,7 @@ class PersonSerializer(serializers.ModelSerializer, ChartHelperMixin):
     def person_current_salary(self):
         if not hasattr(self, '_current_salary'):
             self._current_salary = self.person_current_job.salaries.get(
-              vintage__standardized_file__reporting_year=self.context['data_year']
+                vintage__standardized_file__reporting_year=self.context['data_year']
             )
         return self._current_salary
 

--- a/payroll/serializers.py
+++ b/payroll/serializers.py
@@ -614,7 +614,9 @@ class PersonSerializer(serializers.ModelSerializer, ChartHelperMixin):
     @property
     def person_current_salary(self):
         if not hasattr(self, '_current_salary'):
-            self._current_salary = self.person_current_job.salaries.get()
+            self._current_salary = self.person_current_job.salaries.get(
+              vintage__standardized_file__reporting_year=self.context['data_year']
+            )
         return self._current_salary
 
     @property

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -212,6 +212,8 @@ class EntityLookup(ListView, PayrollSearchMixin):
         extra_search_kwargs = {
             'expenditure_d': '[1000000 TO *]',
             'salary_d': '[100000 TO *]',
+            'group': 'true',
+            'group.field': 'slug',
         }
 
         units = self.search(

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -126,7 +126,7 @@ class PersonView(DetailView, ChartHelperMixin):
         context = super().get_context_data(**kwargs)
 
         most_recent_year = self.object.jobs.aggregate(
-            most_recent_year=Max('vintage__standardized_file__reporting_year')
+            most_recent_year=Max('salaries__vintage__standardized_file__reporting_year')
         )['most_recent_year']
 
         serializer = PersonSerializer(self.object, context={


### PR DESCRIPTION
## Description

See title. Closes #451, closes #453.

## Testing instructions

- Navigate to the homepage, and query for "Chicago". Confirm you see distinct unit and person suggestions.
- Navigate to [this person page](https://bga-payroll.datamade.us/person/dennis-reboletti-e4bc2e3e/) and confirm that it is displayed as expected.