### PR TITLE
Use total pay in person index/serializer, sanitize Solr queries

### DIFF
--- a/payroll/management/commands/build_solr_index.py
+++ b/payroll/management/commands/build_solr_index.py
@@ -276,7 +276,7 @@ class Command(BaseCommand):
                 'entity_type': 'Person',
                 'year': year,
                 'title_s': job.position.title,
-                'salary_d': salary.amount,
+                'salary_d': (salary.amount or 0) + (salary.extra_pay or 0),
                 'employer_ss': employer_slug,
                 'text': text,
             }

--- a/payroll/search.py
+++ b/payroll/search.py
@@ -350,7 +350,7 @@ class PayrollSearchMixin(object):
 
             if index_field == 'name':
                 # Allow for terms to appear in any order
-                value = '({})'.format(value)
+                value = '({})'.format(self._santize(value))
 
             query_parts.append('{0}:{1}'.format(index_field, value))
 
@@ -378,6 +378,14 @@ class PayrollSearchMixin(object):
                 query_parts.append(range_q)
 
         return query_parts
+
+    def _santize(self, term):
+        '''
+        Escape characters for Solr. Taken verbatim from
+        https://github.com/django-haystack/pysolr/issues/23#issuecomment-21932681
+        '''
+        ESCAPE_CHARS_RE = re.compile(r'(?<!\\)(?P<char>[&|+\-!(){}[\]^"~*?:])')
+        return ESCAPE_CHARS_RE.sub(r'\\\g<char>', term)
 
 
 class FacetingMixin(object):

--- a/payroll/serializers.py
+++ b/payroll/serializers.py
@@ -727,7 +727,8 @@ class PersonSerializer(serializers.ModelSerializer, ChartHelperMixin):
             return source_file.url
 
     def get_noindex(self, obj):
-        return self.person_current_salary.amount < 30000 or obj.noindex
+        total_pay = (self.person_current_salary.amount or 0) + (self.person_current_salary.extra_pay or 0)
+        return total_pay < 30000 or obj.noindex
 
     def get_employee_salary_json(self, obj):
         base_pay = {

--- a/templates/jinja2/partials/breadcrumbs.html
+++ b/templates/jinja2/partials/breadcrumbs.html
@@ -14,7 +14,7 @@
     {% if '/person/' in request.path %} {# Link if shown on person page #}
       <a href="/{{ entity.endpoint }}/{{ entity.slug }}">{{ entity.name }}</a>
     {% else %}
-      {{ entity }}
+      {{ entity.name }}
     {% endif %}
   </li>
 


### PR DESCRIPTION
## Description

See title.

- Total pay: Handles #460, handles #448 
- Solr sanitization: Handles #459, handles #346

## Testing instructions

- Rebuild the person index
- Visit https://bga-payroll.datamade.us/search/?entity_type=person&employer=calumet-park-71c48e4c&page=16 and confirm the page loads as expected
- Visit http://localhost:8000/search/?name=Walter%20F%20O%22Neil&entity_type=unit%2Cdepartment%2Cperson and confirm the page loads as expected