### PR TITLE
Add data year filter to search, data year parameters search results and links around the site

### DIFF
--- a/bga_database/static/js/employer.js
+++ b/bga_database/static/js/employer.js
@@ -36,12 +36,12 @@ const Unit = {
   update: function(year, result) {
     Employer.commonUpdate(year, result);
 
-    Unit.updateSummaryCard(result);
-    Unit.updateEmployeeCard(result);
-    Unit.updateDepartmentCard(result);
+    Unit.updateSummaryCard(year, result);
+    Unit.updateEmployeeCard(year, result);
+    Unit.updateDepartmentCard(year, result);
   },
 
-  updateSummaryCard: function (result) {
+  updateSummaryCard: function (year, result) {
     try {
       $('#entity-salary-percentile').text(result.salary_percentile);
       $('#entity-expenditure-percentile').text(result.expenditure_percentile);
@@ -52,7 +52,7 @@ const Unit = {
     if ( result.highest_spending_department === null ) {
       $('#entity-department-statistics').hide();
     } else {
-      $('#entity-highest-spending-department').attr('href', '/department/' + result.highest_spending_department.slug);
+      $('#entity-highest-spending-department').attr('href', '/department/' + result.highest_spending_department.slug + '/?data_year=' + year);
       $('#entity-highest-spending-department').text(result.highest_spending_department.name);
       $('#entity-highest-spending-department-expenditure').text(result.highest_spending_department.amount);
       $('#entity-department-statistics').show();
@@ -61,7 +61,7 @@ const Unit = {
     ChartHelper.make_salary_chart(result.employee_salary_json, 'employee');
   },
 
-  updateEmployeeCard: function (result) {
+  updateEmployeeCard: function (year, result) {
     $('#entity-salaries').empty();
 
     $.each(result.salaries, function (idx, salary) {
@@ -73,7 +73,7 @@ const Unit = {
       );
 
       const employerLink = Employer.makeLink(
-        '/' + salary.employer_endpoint + '/' + salary.employer_slug,
+        '/' + salary.employer_endpoint + '/' + salary.employer_slug + '/?data_year=' + year,
         salary.employer
       );
 
@@ -93,14 +93,14 @@ const Unit = {
     $('#entity-median-ep').text(result.median_ep);
   },
 
-  updateDepartmentCard: function (result) {
+  updateDepartmentCard: function (year, result) {
     $('#department-salaries').empty();
 
     if ( result.department_salaries.length > 0 ) {
       $.each(result.department_salaries, function (idx, salary) {
         const tRow = $('<tr>');
         const departmentLink = Employer.makeLink(
-          '/department/' + salary.slug,
+          '/department/' + salary.slug + '/?data_year=' + year,
           salary.name
         );
 

--- a/payroll/search.py
+++ b/payroll/search.py
@@ -5,8 +5,10 @@ import re
 import sys
 
 from django.conf import settings
+from django.db.models import Max
 import pysolr
 
+from data_import.models import StandardizedFile
 from payroll.models import Unit, Department, Person
 from payroll.utils import employers_from_slugs
 
@@ -333,6 +335,11 @@ class PayrollSearchMixin(object):
 
         value_params = {k: v for k, v in params.items()
                         if k not in range_params}
+
+        if 'year' not in value_params:
+            value_params['year'] = StandardizedFile.objects.aggregate(
+                latest_year=Max('reporting_year')
+            )['latest_year']
 
         query_parts = chain(self._value_q(value_params), self._range_q(range_params))
 

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -202,6 +202,12 @@ class SearchView(ListView, PayrollSearchMixin, FacetingMixin):
         context['facets'] = facets
         context['search_limit'] = settings.SEARCH_LIMIT
 
+        data_years = StandardizedFile.objects.distinct('reporting_year')\
+                                             .order_by('-reporting_year')\
+                                             .values_list('reporting_year', flat=True)
+
+        context['data_years'] = list(data_years)
+
         return context
 
 

--- a/templates/jinja2/partials/search_result.html
+++ b/templates/jinja2/partials/search_result.html
@@ -1,5 +1,5 @@
 {% with endpoint=result.id.split('.')[0] %}
-    <a href="/{{ endpoint }}/{{ result.slug }}/" class="search-result">{{ result.name }}</a>
+    <a href="/{{ endpoint }}/{{ result.slug }}/{% if endpoint != 'person' %}?data_year={{ result['year'] }}{% endif %}" class="search-result">{{ result.name }}</a>
 
     {% if endpoint == 'person' %}
         <span class="badge badge-primary">

--- a/templates/jinja2/search_results.html
+++ b/templates/jinja2/search_results.html
@@ -52,7 +52,7 @@ Search results
 
         <div class="row mb-4 mt-3">
             <div class="col">
-                <strong class="mr-2">Result type:</strong> <a class="btn {% if 'entity_type' in request.GET and 'unit' in request.GET['entity_type'] %}bg-light{% endif %} p-1 rounded" href="{{ request.path }}?entity_type=unit&{{ request|query_transform(drop_keys=['entity_type', 'page']) }}"><i class="fas fa-building"></i> Unit</a> &nbsp;
+                <h5 class="mr-2 d-inline text-dark">Result type:</h5> <a class="btn {% if 'entity_type' in request.GET and 'unit' in request.GET['entity_type'] %}bg-light{% endif %} p-1 rounded" href="{{ request.path }}?entity_type=unit&{{ request|query_transform(drop_keys=['entity_type', 'page']) }}"><i class="fas fa-building"></i> Unit</a> &nbsp;
                 <a class="btn {% if 'entity_type' in request.GET and 'department' in request.GET['entity_type'] %}bg-light{% endif %} p-1" href="{{ request.path }}?entity_type=department&{{ request|query_transform(drop_keys=['entity_type', 'page']) }}"><i class="far fa-building"></i> Department</a> &nbsp;
                 <a class="btn {% if 'entity_type' in request.GET and 'person' in request.GET['entity_type'] %}bg-light{% endif %} p-1" href="{{ request.path }}?entity_type=person&{{ request|query_transform(drop_keys=['entity_type', 'page']) }}"><i class="far fa-address-card"></i> Person</a> &nbsp;
                 <a class="btn {% if 'entity_type' in request.GET and request.GET.entity_type == 'unit,department,person' %}bg-light{% endif %} p-1 rounded" href="{{ request.path }}?entity_type=unit,department,person&{{ request|query_transform(drop_keys=['entity_type', 'page']) }}"><i class="fas fa-globe"></i> All</a> &nbsp;
@@ -64,6 +64,21 @@ Search results
         <div class="row">
             {% if results %}
             <div class="col-md-4">
+                <div class="mb-3">
+                    <h5 class="text-dark">Data year</h5>
+                    <div class="dropdown">
+                      <a class="btn btn-lg w-100 bg-light dropdown-toggle text-left" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        {{ request.GET.get('year', data_years.0) }}
+                      </a>
+
+                      <div class="dropdown-menu w-100" aria-labelledby="dropdownMenuLink">
+                        {% for year in data_years %}
+                            <a class="dropdown-item" href="{{ request.path }}?{{ request|query_transform(drop_keys=['year']) }}&year={{ year }}">{{ year }}</a>
+                        {% endfor %}
+                      </div>
+                    </div>
+                </div>
+
                 {% if request.GET.entity_type %}
                     {% set requested_entities = request.GET.entity_type.split(',') %}
                 {% else %}


### PR DESCRIPTION
## Description

This PR:

- Adds a data year filter to the search, defaulting to the most recent year if a data year parameter is not provided, closes #458 
- Adds data year parameters to search results, closes #456
- Adds data year parameters to employer links on unit/department detail pages, connects #466