### PR TITLE
Don't calculate percent change when starting amount is 0

### DIFF
--- a/payroll/serializers.py
+++ b/payroll/serializers.py
@@ -788,7 +788,7 @@ class PersonSerializer(serializers.ModelSerializer, ChartHelperMixin):
 
             change.update({
                 'amount_delta': latest_amount - earliest_amount,
-                'amount_percent_change': (latest_amount - earliest_amount) / earliest_amount,
+                'amount_percent_change': (latest_amount - earliest_amount) / earliest_amount if earliest_amount > 0 else None,
             })
 
         salaries_with_extra_pay = list(filter(lambda x: x.extra_pay is not None, ordered_salaries))
@@ -799,7 +799,7 @@ class PersonSerializer(serializers.ModelSerializer, ChartHelperMixin):
 
             change.update({
                 'extra_pay_delta': latest_amount - earliest_amount,
-                'extra_pay_percent_change': (latest_amount - earliest_amount) / earliest_amount,
+                'extra_pay_percent_change': (latest_amount - earliest_amount) / earliest_amount if earliest_amount > 0 else None,
             })
 
         return change

--- a/templates/jinja2/partials/person_jobs_card.html
+++ b/templates/jinja2/partials/person_jobs_card.html
@@ -83,10 +83,12 @@
         <div>
           {% if 'amount_delta' in change_in_salary %}
             <h4 class="d-inline">{{ change_in_salary.amount_delta|format_salary }}</h4>
+            {% if change_in_salary.amount_percent_change %}
             <sup class="d-inline text-{% if change_in_salary.amount_delta >= 0 %}success{% else%}danger{% endif %} px-1 m-0">
               {% if change_in_salary.amount_delta >= 0 %}+{% endif %}
               {{ change_in_salary.amount_percent_change|format_percentile }}
-            </sup><br />
+            </sup>
+            {% endif %}<br />
             <small class="text-muted">Net Change in Base Salary</small>
           {% else %}
             <h4>Not reported</h4>
@@ -97,10 +99,12 @@
         <div>
           {% if 'extra_pay_delta' in change_in_salary %}
             <h4 class="d-inline">{{ change_in_salary.extra_pay_delta|format_salary }}</h4>
+            {% if change_in_salary.extra_pay_percent_change %}
             <sup class="d-inline text-{% if change_in_salary.extra_pay_delta >= 0 %}success{% else%}danger{% endif %} px-1 m-0">
               {% if change_in_salary.extra_pay_delta >= 0 %}+{% endif %}
               {{ change_in_salary.extra_pay_percent_change|format_percentile }}
-            </sup><br />
+            </sup>
+            {% endif %}<br />
             <small class="text-muted">Net Change in Extra Pay</small>
           {% else %}
             <h4>Not reported</h4>


### PR DESCRIPTION
## Description

This PR only calculates percent change in base/extra pay if the first value is not 0.

Reference: https://money.stackexchange.com/questions/84534/what-is-the-correct-answer-for-percent-change-when-the-start-amount-is-zero-doll

Closes #465.