### PR TITLE
Dynamically populate story feed

### DIFF
--- a/bga_database/static/css/custom.css
+++ b/bga_database/static/css/custom.css
@@ -224,3 +224,15 @@ h5 {
   height: 1rem;
   border-width: 0.2em;
 }
+
+.text-serif {
+  font-family: Georgia, "Times New Roman", "DejaVu Serif", serif;
+}
+
+#story-feed-stories h5 {
+  text-transform: unset;
+}
+
+#story-feed-stories h5 > a {
+  color: unset;
+}

--- a/bga_database/static/js/story_feed.js
+++ b/bga_database/static/js/story_feed.js
@@ -6,7 +6,10 @@ function populateStoryFeed() {
             var storyItem = $('<div class="p-3" />');
 
             var title = $('<h5 />').append(
-                $('<a />').attr('href', entry.link).text(entry.title)
+                $('<a />').attr({
+                    'href': entry.link,
+                    'target': '_blank'
+                }).text(entry.title)
             );
 
             var summary = $('<p class="text-serif my-2" />').text(entry.summary);

--- a/bga_database/static/js/story_feed.js
+++ b/bga_database/static/js/story_feed.js
@@ -1,0 +1,26 @@
+function populateStoryFeed() {
+    $.get('/story-feed/', function (data) {
+        var container = $('#story-feed-stories');
+
+        $.each(data.entries, function (idx, entry) {
+            var storyItem = $('<div class="p-3" />');
+
+            var title = $('<h5 />').append(
+                $('<a />').attr('href', entry.link).text(entry.title)
+            );
+
+            var summary = $('<p class="text-serif my-2" />').text(entry.summary);
+            var date = $('<p class="mb-0" />').text(entry.date);
+
+            storyItem.append(title, summary, date);
+
+            container.append(storyItem);
+
+            if ( idx < data.entries.length - 1 ) {
+                container.append($('<hr class="w-75 mx-auto" />'));
+            }
+        });
+    });
+};
+
+populateStoryFeed();

--- a/bga_database/static/js/story_feed.js
+++ b/bga_database/static/js/story_feed.js
@@ -24,6 +24,6 @@ function populateStoryFeed() {
             }
         });
     });
-};
+}
 
 populateStoryFeed();

--- a/bga_database/urls.py
+++ b/bga_database/urls.py
@@ -49,6 +49,7 @@ urlpatterns = [
     path('person/<str:slug>/', cache_page(EIGHT_HOURS)(payroll_views.PersonView.as_view()), name='person'),
     path('entity-lookup/', payroll_views.EntityLookup.as_view(), name='entity-lookup'),
     path('search/', payroll_views.SearchView.as_view(), name='search'),
+    path('story-feed/', payroll_views.StoryFeed.as_view(), name='story-feed'),
     path('<int:error_code>', payroll_views.error, name='error'),
 
     # user auth

--- a/bga_database/urls.py
+++ b/bga_database/urls.py
@@ -49,7 +49,7 @@ urlpatterns = [
     path('person/<str:slug>/', cache_page(EIGHT_HOURS)(payroll_views.PersonView.as_view()), name='person'),
     path('entity-lookup/', payroll_views.EntityLookup.as_view(), name='entity-lookup'),
     path('search/', payroll_views.SearchView.as_view(), name='search'),
-    path('story-feed/', payroll_views.StoryFeed.as_view(), name='story-feed'),
+    path('story-feed/', cache_page(EIGHT_HOURS)(payroll_views.StoryFeed.as_view()), name='story-feed'),
     path('<int:error_code>', payroll_views.error, name='error'),
 
     # user auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ pysolr==3.7.0
 python-dateutil==2.8.1
 sentry-sdk==0.5.1
 kombu==4.3.0
+feedparser==5.2.1
 
 pytest==3.4.1
 attrs==19.1.0

--- a/templates/jinja2/department.html
+++ b/templates/jinja2/department.html
@@ -91,6 +91,8 @@
 {% endblock %}
 
 {% block extra_js %}
+<script type="text/javascript" src="{{ static('js/story_feed.js') }}"></script>
+
 {% compress js %}
 <script type="module">
   import { initDataYearToggle } from  'js/data_year_toggle'

--- a/templates/jinja2/index.html
+++ b/templates/jinja2/index.html
@@ -137,8 +137,9 @@
 
 {% block extra_js %}
 <script type="text/javascript" src="{{ static('js/lib/jquery-ui.min.js') }}"></script>
-<script src="{{ static('js/search.js') }}"></script>
+<script type="text/javascript" src="{{ static('js/search.js') }}"></script>
 <script type="text/javascript" src="{{ static('js/entity_auto_complete.js') }}"></script>
+<script type="text/javascript" src="{{ static('js/story_feed.js') }}"></script>
 
 {% compress js %}
 <script type="module">

--- a/templates/jinja2/partials/story_feed.html
+++ b/templates/jinja2/partials/story_feed.html
@@ -5,51 +5,7 @@
         <h5 class="text-light text-uppercase m-0">From the newsroom</h5>
       </div>
 
-      <div class="row p-3">
-        <div class="col-7">
-          <h5 style="text-transform: unset;">Lorem ipsum officia eiusmod</h5>
-          <p>August 19, 2020</p>
-        </div>
-        <div class="col-5">
-          <img src="https://via.placeholder.com/100" class="w-100" />
-        </div>
+      <div id="story-feed-stories" class="p-3">
       </div>
-
-      <hr class="w-75 mx-auto" />
-
-      <div class="row p-3">
-        <div class="col-7">
-          <h5 style="text-transform: unset;">Ut ullamco laboris</h5>
-          <p>August 18, 2020</p>
-        </div>
-        <div class="col-5">
-          <img src="https://via.placeholder.com/100" class="w-100" />
-        </div>
-      </div>
-
-      <hr class="w-75 mx-auto" />
-
-      <div class="row p-3">
-        <div class="col-7">
-          <h5 style="text-transform: unset;">Proident sint est</h5>
-          <p>August 18, 2020</p>
-        </div>
-        <div class="col-5">
-          <img src="https://via.placeholder.com/100" class="w-100" />
-        </div>
-      </div>
-
-      <hr class="w-75 mx-auto" />
-
-      <div class="row p-3">
-        <div class="col-7">
-          <h5 style="text-transform: unset;">Lorem ipsum aliqua quis sunt velit id</h5>
-          <p>August 17, 2020</p>
-        </div>
-        <div class="col-5">
-          <img src="https://via.placeholder.com/100" class="w-100" />
-        </div>
-      </div>
-    </div>
   </div>
 </div>

--- a/templates/jinja2/person.html
+++ b/templates/jinja2/person.html
@@ -130,6 +130,8 @@
 {% endblock %}
 
 {% block extra_js %}
+<script type="text/javascript" src="{{ static('js/story_feed.js') }}"></script>
+
 {% compress js %}
 <script type="text/javascript" type="module">
   import { ChartHelper } from 'js/chart_helper'

--- a/templates/jinja2/unit.html
+++ b/templates/jinja2/unit.html
@@ -126,6 +126,8 @@
 {% endblock %}
 
 {% block extra_js %}
+<script type="text/javascript" src="{{ static('js/story_feed.js') }}"></script>
+
 {% compress js %}
 <script type="module">
   import { initDataYearToggle } from  'js/data_year_toggle'


### PR DESCRIPTION
## Description

This pull request adds a Django endpoint that retrieves stories from BGA's newsroom RSS feed, and JavaScript to hit the endpoint and populate the story feed on the site. I chose to retrieve the feed in Python in order to cache the response and limit the load on BGA servers (rather than hitting their site every time someone visits a page on the Salaries site). I chose to populate the feed in JavaScript because we cache full templates, and we don't want the feed to be coupled with template caching. (Right now, templates and the RSS endpoint are cached for the same amount of time, but we may want to increase timeout for templates prior to launch; implementing feed caching separately grants us this flexibility.)

## Testing instructions

- Deploy these changes to the staging site. Visit the homepage, a unit page, a department page, and a person page, and confirm the story feed is populated as expected.