### PR TITLE
add csv export for processed salary data

### DIFF
--- a/bga_database/urls.py
+++ b/bga_database/urls.py
@@ -51,6 +51,7 @@ urlpatterns = [
     path('search/', payroll_views.SearchView.as_view(), name='search'),
     path('story-feed/', cache_page(EIGHT_HOURS)(payroll_views.StoryFeed.as_view()), name='story-feed'),
     path('<int:error_code>', payroll_views.error, name='error'),
+    path('download/', payroll_views.DownloadView.as_view(), name='download'),
 
     # user auth
     path('salsa/', include('salsa_auth.urls')),

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -197,9 +197,15 @@ class DownloadView(TemplateView):
             'job__position__employer',
             'job__position__employer__parent'
         )
-        
+
         buffer = PsuedoBuffer()
-        headers = ['name', 'unit', 'department', 'title', 'tenure', 'salary', 'overtime']
+        headers = ['name',
+                   'unit',
+                   'department',
+                   'title',
+                   'tenure',
+                   'salary',
+                   'overtime']
         dict_writer = csv.DictWriter(f=buffer, fieldnames=headers)
 
         def row_generator():
@@ -211,7 +217,7 @@ class DownloadView(TemplateView):
                 name = '{first_name} {last_name}'.format(**name_kwargs)
 
                 start_date = salary.job.start_date.strftime('%m/%d/%Y') if salary.job.start_date else ''  # noqa
-                
+
                 yield {
                     'name': name,
                     'unit': employer.parent,
@@ -221,7 +227,7 @@ class DownloadView(TemplateView):
                     'salary': salary.amount,
                     'overtime': salary.extra_pay
                 }
-                
+
         # DictWriter.writeheader() doesn't work in python 3.5,
         # so this workaround adds the header from dict_writer.fieldnames.
         flat_writer = csv.writer(buffer)
@@ -232,8 +238,8 @@ class DownloadView(TemplateView):
             rows,
             content_type='text/csv'
         )
-        
-        filename = '{employer}-{year}.csv'.format(employer=employer.name, year=year)
+
+        filename = '{employer}-{year}.csv'.format(employer=employer.name, year=year)  # noqa
         response['Content-Disposition'] = 'attachment; filename="{}"'.format(filename)  # noqa
         return response
 

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -8,7 +8,7 @@ from django.core.cache import caches
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.db.models import Max
 from django.http import JsonResponse, HttpResponse, \
-    HttpResponsePermanentRedirect, HttpResponseGone
+    HttpResponsePermanentRedirect, HttpResponseGone, StreamingHttpResponse
 from django.shortcuts import render
 from django.urls import reverse
 from django.views.generic.base import TemplateView
@@ -177,42 +177,64 @@ class PersonView(RedirectDispatchMixin, DetailView, ChartHelperMixin):
         return context
 
 
+class PsuedoBuffer:
+    """An object that implements just the write method of the file-like
+    interface.
+    """
+
+    def write(self, value):
+        """Write the value by returning it, instead of storing in a buffer."""
+        return value
+
+
 class DownloadView(TemplateView):
     def get(self, request, *args, **kwargs):
         slug = request.GET.get('employer')
         year = request.GET.get('year')
         employer = Employer.objects.get(slug=slug)
-        employer_salaries = employer.get_salaries(year=year)
+        employer_salaries = employer.get_salaries(year=year).select_related(
+            'job',
+            'job__person',
+            'job__position',
+            'job__position__employer',
+            'job__position__employer__parent'
+        )
         
-        buffer = StringIO()
-        header = ['name', 'unit', 'department', 'title', 'tenure', 'salary', 'overtime']
-        dict_writer = csv.DictWriter(f=buffer, fieldnames=header)
-        dict_writer.writeheader()
+        buffer = PsuedoBuffer()
+        # todo: don't worry ab this rn. DictWriter requires the argument so leaving it here for now
+        headers = ['name', 'unit', 'department', 'title', 'tenure', 'salary', 'overtime']
+        dict_writer = csv.DictWriter(f=buffer, fieldnames=headers)
 
-        for salary in employer_salaries:
-            name_kwargs = {
-                'first_name': salary.job.person.first_name,
-                'last_name': salary.job.person.last_name
-            }
-            name = '{first_name} {last_name}'.format(**name_kwargs)
+        # todo: move outside the scope of this `get` method?
+        def row_generator():
+            for salary in employer_salaries:
+                name_kwargs = {
+                    'first_name': salary.job.person.first_name,
+                    'last_name': salary.job.person.last_name
+                }
+                name = '{first_name} {last_name}'.format(**name_kwargs)
 
-            start_date = salary.job.start_date.strftime('%m/%d/%Y') if salary.job.start_date else ''  # noqa
-
-            dict_writer.writerow({
-                'name': name,
-                'unit': employer.parent,
-                'department': employer.name,
-                'title': salary.job.position.title,
-                'tenure': start_date,
-                'salary': salary.amount,
-                'overtime': salary.extra_pay
-            })
-
-        buffer.seek(0)
-        response = HttpResponse(buffer, content_type='text/csv')
-        filename = '{employer}-{year}.csv'.format(employer=employer.name, year=year)  # noqa
+                start_date = salary.job.start_date.strftime('%m/%d/%Y') if salary.job.start_date else ''  # noqa
+                
+                yield {
+                    'name': name,
+                    'unit': employer.parent,
+                    'department': employer.name,
+                    'title': salary.job.position.title,
+                    'tenure': start_date,
+                    'salary': salary.amount,
+                    'overtime': salary.extra_pay
+                }
+                
+        rows = row_generator()
+        
+        response = StreamingHttpResponse(
+            (dict_writer.writerow(row) for row in rows),
+            content_type='text/csv'
+        )
+        
+        filename = '{employer}-{year}.csv'.format(employer=employer.name, year=year)
         response['Content-Disposition'] = 'attachment; filename="{}"'.format(filename)  # noqa
-
         return response
 
 

--- a/templates/jinja2/partials/employee_card.html
+++ b/templates/jinja2/partials/employee_card.html
@@ -2,6 +2,7 @@
   <h3 class="card-title mb-4">
     <i class="fas fa-users"></i> Employees
     <small><a id="employee-search-link" href="/search/?entity_type=person&employer={{ entity.slug }}&year={{ request.GET.get('data_year', data_years.0) }}">View all (<span class="entity-headcount"></span>)</a></small>
+    <small><a id="employee-search-link" href="/download/?employer={{ entity.slug }}&year={{ request.GET.get('data_year', data_years.0) }}">Download Data</a></small>
   </h3>
 
   <h4 class="card-subtitle">Top earners in {{ entity }}</h4>


### PR DESCRIPTION
# Overview
Code changes include:
- New view with a url for downloading a csv. The csv is downloadable by year.
- A link in the template so a user can download the data.

Closes #515.

## Notes
Any ideas where this link should exist on the webpage? It's not styled, currently.

## Testing
- Pull down branch `download-csv` and run the app.
- Download data from a department or a unit.
- Let me know if I'm missing any places where this should exist?