### PR TITLE
Order jobs by salary reporting year, not job reporting year

### DIFF
--- a/payroll/models.py
+++ b/payroll/models.py
@@ -445,7 +445,7 @@ class Person(SluggedModel, VintagedModel, SourceFileMixin):
         '''
         return self.jobs\
                    .select_related('position', 'position__employer', 'position__employer__parent')\
-                   .order_by('-vintage__standardized_file__reporting_year')\
+                   .order_by('-salaries__vintage__standardized_file__reporting_year')\
                    .first()
 
     def responding_agency(self, year):


### PR DESCRIPTION
## Description

This PR squashes the bug meanderingly described in #535.

### Testing instructions

- Confirm CI passes.
- Merge to deploy to staging.
- [View Leonard M Shoshi](https://bga-payroll.datamade.us/person/leonard-m-shoshi-20e87a51/) and confirm the page loads without error, and the most recent salary is described in the lead text box.