### PR TITLE
Correctly filter for salaries in a given year, handles #539

### DIFF
--- a/payroll/management/commands/build_solr_index.py
+++ b/payroll/management/commands/build_solr_index.py
@@ -300,11 +300,14 @@ class Command(BaseCommand):
         documents = []
         document_count = 0
 
+        # Select people with salaries in the given data year. Use distinct
+        # because a person can have multiple jobs and salaries, which will
+        # cause them to appear more than once in this queryset.
         people = Person.objects.filter(
-            jobs__vintage__standardized_file__reporting_year__in=self.reporting_years
-        ).iterator()
+            jobs__salaries__vintage__standardized_file__reporting_year__in=self.reporting_years
+        ).distinct()
 
-        for person in people:
+        for person in people.iterator():
             for document in self._make_person_index(person):
                 documents.append(document)
 


### PR DESCRIPTION
## Description

Similarly to #536, this PR addresses a bug that omitted people from indexing if they held their job in a prior year, by selecting people to index based on the vintage of their salary, rather than their job.

### Testing instructions

- Tested locally by having 2019 data in my database, then running `docker-compose run --rm app python manage.py build_solr_index --entity-types people --reporting_year 2019 --recreate` and finally confirming that the correct number of people were indexed for a sample of employers.
- Once this is approved, I'll reindex the staging site with the same command (omitting reporting year), and we should spot check the examples in #539 to confirm they appear in the search index.