### PR TITLE
fix departments and downloads in data download, closes #564

### DIFF
--- a/payroll/views.py
+++ b/payroll/views.py
@@ -218,8 +218,8 @@ class DownloadView(TemplateView):
 
                 yield {
                     'name': name,
-                    'unit': employer.parent,
-                    'department': employer.name,
+                    'unit': salary.job.position.employer.parent,
+                    'department': salary.job.position.employer,
                     'title': salary.job.position.title,
                     'tenure': start_date,
                     'salary': salary.amount,


### PR DESCRIPTION
# Overview

Fixes bug from #564.

# Test

* pull down `fix_units_in_data_download` branch
* visit a unit and a department
* download a CSV
* make sure that employees are listed as belonging to the right department