### PR TITLE
Improve download link styling and source data language

### DIFF
--- a/bga_database/static/css/custom.css
+++ b/bga_database/static/css/custom.css
@@ -78,7 +78,7 @@ div#intro-text {
   color: #fff;
 }
 
-.btn-primary:hover {
+.btn-primary:hover, .btn-download:hover {
   color: #fff200;
   background-color: #003a63;
   border-color: #003a63;
@@ -89,6 +89,21 @@ div#intro-text {
   color: #003a63;
   text-decoration: none;
 }
+
+.btn-download {
+  color: #fff;
+  background-color: #003a63;
+  border-color: #003a63;
+}
+
+@media only screen and (max-width: 900px) {
+  .btn-download {
+    color: #fff;
+    background-color: #6c757d;
+    border-color: #6c757d;
+}
+}
+
 
 .search-results > .table {
   margin: -1px;

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -218,8 +218,8 @@ class DownloadView(TemplateView):
 
                 yield {
                     'name': name,
-                    'unit': employer.parent,
-                    'department': employer.name,
+                    'unit': salary.job.position.employer.parent,
+                    'department': salary.job.position.employer,
                     'title': salary.job.position.title,
                     'tenure': start_date,
                     'salary': salary.amount,

--- a/templates/jinja2/partials/employee_card.html
+++ b/templates/jinja2/partials/employee_card.html
@@ -1,12 +1,12 @@
 <div class="card-body">
-  <div class="d-flex flex-row justify-content-around">
-    <h3 class="card-title mb-4">
+  <div class="d-flex flex-row justify-content-around flex-wrap mb-4">
+    <h3 class="card-title">
       <i class="fas fa-users"></i> Employees
     </h3>
     <div class="d-flex justify-content-between w-75">
       <a class="lead" id="employee-search-link" href="/search/?entity_type=person&employer={{ entity.slug }}&year={{ request.GET.get('data_year', data_years.0) }}">View all (<span class="entity-headcount"></span>)</a>
       <div>
-        <a class="btn btn-primary" id="employee-download-link" href="/download/?employer={{ entity.slug }}&year={{ request.GET.get('data_year', data_years.0) }}">Download Data</a>
+        <a class="btn btn-download" id="employee-download-link" href="/download/?employer={{ entity.slug }}&year={{ request.GET.get('data_year', data_years.0) }}">Download Data</a>
       </div>
     </div>
   </div>

--- a/templates/jinja2/partials/employee_card.html
+++ b/templates/jinja2/partials/employee_card.html
@@ -1,9 +1,15 @@
 <div class="card-body">
-  <h3 class="card-title mb-4">
-    <i class="fas fa-users"></i> Employees
-    <small><a id="employee-search-link" href="/search/?entity_type=person&employer={{ entity.slug }}&year={{ request.GET.get('data_year', data_years.0) }}">View all (<span class="entity-headcount"></span>)</a></small>
-    <small><a id="employee-search-link" href="/download/?employer={{ entity.slug }}&year={{ request.GET.get('data_year', data_years.0) }}">Download Data</a></small>
-  </h3>
+  <div class="d-flex flex-row justify-content-around">
+    <h3 class="card-title mb-4">
+      <i class="fas fa-users"></i> Employees
+    </h3>
+    <div class="d-flex justify-content-between w-75">
+      <a class="lead" id="employee-search-link" href="/search/?entity_type=person&employer={{ entity.slug }}&year={{ request.GET.get('data_year', data_years.0) }}">View all (<span class="entity-headcount"></span>)</a>
+      <div>
+        <a class="btn btn-primary" id="employee-download-link" href="/download/?employer={{ entity.slug }}&year={{ request.GET.get('data_year', data_years.0) }}">Download Data</a>
+      </div>
+    </div>
+  </div>
 
   <h4 class="card-subtitle">Top earners in {{ entity }}</h4>
   {% include 'partials/person_table.html' %}

--- a/templates/jinja2/partials/source_link.html
+++ b/templates/jinja2/partials/source_link.html
@@ -1,7 +1,7 @@
 <p class="text-right">
   <small>
     <strong>Data year:</strong> <span class="entity-data-year"></span>
-    <span class="source-span">(<a class="entity-source-link" rel="nofollow">Source</a>)</span>
+    <span class="source-span">(<a class="entity-source-link" rel="nofollow">Source Document</a>)</span>
     <span class="no-source-span hidden"><em class="text-secondary">Source coming soon</em></span>
   </small>
 </p>

--- a/templates/jinja2/person.html
+++ b/templates/jinja2/person.html
@@ -106,7 +106,7 @@
                 <small>
                   <strong>Data year:</strong> {{ data_year }}
                   {% if source_link %}
-                  (<a class="entity-source-link" href="{{ source_link }}" rel="nofollow">Source</a>)
+                  (<a class="entity-source-link" href="{{ source_link }}" rel="nofollow">Source Document</a>)
                   {% else %}
                   <em class="text-secondary">Source coming soon</em>
                   {% endif %}


### PR DESCRIPTION
## Overview
Closes issues:
- #565
- #566

## Demo
This includes the new styling + the language change for the source data:
<img width="869" alt="Screen Shot 2021-11-16 at 11 21 46 AM" src="https://user-images.githubusercontent.com/38969506/142034323-9aa5a06d-88bc-48ca-81d6-602766a91b80.png">


## Testing
- pull down `download-links` branch
- test links and make sure they look good