### PR TITLE
fix sticky button bug

### DIFF
--- a/bga_database/static/bootstrap/scss/utilities/_position.scss
+++ b/bga_database/static/bootstrap/scss/utilities/_position.scss
@@ -35,3 +35,11 @@ $positions: static, relative, absolute, fixed, sticky;
     z-index: $zindex-sticky;
   }
 }
+
+.sticky-top-button {
+  @supports (position: sticky) {
+    position: sticky;
+    top: 55px;
+    z-index: $zindex-sticky;
+  }
+} 

--- a/bga_database/static/bootstrap/scss/utilities/_position.scss
+++ b/bga_database/static/bootstrap/scss/utilities/_position.scss
@@ -35,11 +35,3 @@ $positions: static, relative, absolute, fixed, sticky;
     z-index: $zindex-sticky;
   }
 }
-
-.sticky-top-button {
-  @supports (position: sticky) {
-    position: sticky;
-    top: 55px;
-    z-index: $zindex-sticky;
-  }
-} 

--- a/bga_database/static/css/bootstrap-overrides.css
+++ b/bga_database/static/css/bootstrap-overrides.css
@@ -5249,7 +5249,15 @@ button.bg-dark:focus {
   .sticky-top {
     position: sticky;
     top: 0;
-    z-index: 1020; } }
+    z-index: 1020; 
+  } 
+  
+  .sticky-top-button {
+    position: sticky;
+    top: 55px;
+    z-index: 1020; 
+  } 
+}
 
 .sr-only {
   position: absolute;

--- a/bga_database/static/css/bootstrap-overrides.css
+++ b/bga_database/static/css/bootstrap-overrides.css
@@ -5251,12 +5251,6 @@ button.bg-dark:focus {
     top: 0;
     z-index: 1020; 
   } 
-  
-  .sticky-top-button {
-    position: sticky;
-    top: 55px;
-    z-index: 1020; 
-  } 
 }
 
 .sr-only {

--- a/bga_database/static/css/custom.css
+++ b/bga_database/static/css/custom.css
@@ -255,3 +255,11 @@ h5 {
 #story-feed-stories h5 > a {
   color: unset;
 }
+
+@supports (position: sticky) {
+  .sticky-top-button {
+    position: sticky;
+    top: 55px;
+    z-index: 1020; 
+  } 
+}

--- a/templates/jinja2/department.html
+++ b/templates/jinja2/department.html
@@ -19,7 +19,7 @@
       </nav>
     </div>
 
-    <div class="sticky-top">
+    <div class="sticky-top-button">
       <div class="float-right pt-2 ml-5">
         {% include 'partials/year_selector.html' %}
       </div>

--- a/templates/jinja2/unit.html
+++ b/templates/jinja2/unit.html
@@ -19,7 +19,7 @@
       </nav>
     </div>
 
-    <div class="sticky-top">
+    <div class="sticky-top-button">
       <div class="float-right pt-2 ml-5">
         {% include 'partials/year_selector.html' %}
       </div>


### PR DESCRIPTION
## Overview
Closes issue #531.

### Demo
![sticky-top](https://user-images.githubusercontent.com/38969506/142231847-0046a380-8c21-4d78-bddd-07494ffe0550.gif)

### Notes
The existing `sticky-top` CSS was declared in two places: `bootstrap-overrides.css` and `_position.css`. I changed it in `bootstrap-overrides.css` and this worked. I wasn't sure about the purpose of `_position.css` file since the existing `sticky-top` CSS declaration was already set elsewhere, so I added it there just to be safe.

## Testing
- Pull down `sticky-button` branch
- Visit a department and unity page
- Make sure the button looks right