### PR TITLE
show download button for authenticated users only

### DIFF
--- a/bga_database/static/js/employer.js
+++ b/bga_database/static/js/employer.js
@@ -101,7 +101,11 @@ var Unit = {
     ChartHelper.make_payroll_expenditure_chart(result.payroll_expenditure);
 
     Employer.updateLink('#employee-search-link', year);
-    Employer.updateLink('#employee-download-link', year);
+
+    // check if it exists in case it's not on the page due to unauthenticated user
+    if ($('#employee-download-link').length) {
+      Employer.updateLink('#employee-download-link', year);
+    }
 
     $('.entity-median-tp').text(result.median_tp);
     $('#entity-median-bp').text(result.median_bp);
@@ -183,7 +187,11 @@ var Department = {
     ChartHelper.make_payroll_expenditure_chart(result.payroll_expenditure);
 
     Employer.updateLink('#employee-search-link', year);
-    Employer.updateLink('#employee-download-link', year);
+    
+    // check if it exists in case it's not on the page due to unauthenticated user
+    if ($('#employee-download-link').length) {
+      Employer.updateLink('#employee-download-link', year);
+    }
 
     $('.entity-median-tp').text(result.median_tp);
     $('#entity-median-bp').text(result.median_bp);

--- a/payroll/views.py
+++ b/payroll/views.py
@@ -103,6 +103,13 @@ class RedirectDispatchMixin:
 class EmployerView(RedirectDispatchMixin, DetailView, ChartHelperMixin):
     context_object_name = 'entity'
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        
+        context['authenticated'] = self.request.COOKIES.get(settings.SALSA_AUTH_COOKIE_NAME)
+
+        return context
+
 
 class UnitView(EmployerView):
     model = Unit

--- a/templates/jinja2/partials/employee_card.html
+++ b/templates/jinja2/partials/employee_card.html
@@ -5,9 +5,11 @@
     </h3>
     <div class="d-flex justify-content-between w-75">
       <a class="lead" id="employee-search-link" href="/search/?entity_type=person&employer={{ entity.slug }}&year={{ request.GET.get('data_year', data_years.0) }}">View all (<span class="entity-headcount"></span>)</a>
-      <div>
-        <a class="btn btn-download" id="employee-download-link" href="/download/?employer={{ entity.slug }}&year={{ request.GET.get('data_year', data_years.0) }}" rel="nofollow">Download Data</a>
-      </div>
+      {% if authenticated %}
+        <div>
+          <a class="btn btn-download" id="employee-download-link" href="/download/?employer={{ entity.slug }}&year={{ request.GET.get('data_year', data_years.0) }}" rel="nofollow">Download Data</a>
+        </div>
+      {% endif %}
     </div>
   </div>
 


### PR DESCRIPTION
## Overview
Closes #569.

### Notes
Instead of prompting the login modal, I'm hiding the download data button. This is a simpler implementation than trying to get the salsa auth plugin to fit this use case. I discussed with Hannah this implementation. 

I've also added some logic in `employer.js` to check if that button exists before executing the related code, otherwise the data selector gets stuck in a loading state.

## Testing
- `git pull origin authenticated-download`
- Not sure how to test with the salsa cookie, so you'll need to spoof it in the code. In line 109 of `views.py`, set `context['authenticated']` to `True` and `False` to test.
  - Make sure the download data button does or doesn't show, depending on how you spoofed it in the view code.
  - Make sure the date selection dropdown loads correctly
  - Make sure the download data button uses the correct year