### PR TITLE
add google tag manager with download data event tracking

### DIFF
--- a/templates/jinja2/base.html
+++ b/templates/jinja2/base.html
@@ -6,6 +6,14 @@
 
     <title>{% block title %}{% endblock %} - Illinois Public Salaries Database</title>
 
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-KDVKMFP');</script>
+    <!-- End Google Tag Manager -->
+
     <meta content="Review, explore and compare compensation for public employees throughout Illinois." name="description" />
     <meta content="Better Government Association" name="author" />
 
@@ -146,24 +154,10 @@
     <script src="{{ static('js/lib/highcharts.src.js') }}"></script>
     <script src="{{ static('js/lib/pattern-fill.js') }}"></script>
 
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-18960172-1"></script>
-
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-18960172-1');
-
-      // Track source file downloads
-      $('.entity-source-link').click(function(e) {
-        var sourceLink = e.target.href;
-
-        gtag('event', 'downloaded', {
-          'event_category': 'downloads',
-          'event_label': sourceLink
-        });
-      })
-    </script>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KDVKMFP"
+      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
 
     {% block extra_js %}{% endblock %}
   </body>


### PR DESCRIPTION
## Overview
For issues:
- #556
- #551

### Notes
This new setup requires some orchestration between the new-ish Google Tag Manager console and the familiar Google Analytics console. It took more time than expected to figure it out, but I understand it now (somewhat). GTM provides non-technical users a way to setup Google Analytics event tracking within the GTM admin console, without making any code changes.

#### Google Tag Manager console
I followed [this guide to implement the click tracking](https://www.analyticsmania.com/post/track-clicks-with-google-analytics-4-and-gtm/).

In the Google Tag Management console, I created two triggers:
1. `Download Source Data Event`
2. `Download Standardized Data Event`

Both of these triggers are attached to the same `Download Data Event Tag`.

#### Google Analytics console
When a user clicks on either of the links for the triggers, it will log in Google Analytics with the `download_data_event`.
<img width="395" alt="Screen Shot 2021-11-22 at 11 37 41 AM" src="https://user-images.githubusercontent.com/38969506/142908927-3c76fc56-96b2-4f75-80c1-57e4492fbf17.png">

BGA users will be able to distinguish between the download triggers (standardized data vs source data) with the help of values in `download_data_text` and `download_data_url`. We can separate these two triggers to have their own tags if we want, but for this iteration all download events are tagged as a `download_data_event`. 

Note that the Google Tag Manager in GA4 tracks file downloads by default. I turned this off since I thought it would be confusing to have two different file download event types, and decided to consolidate under this one custom `download_data_event`. Also, the source file was the only download tracked by this, since the new data download requests the server and doesn't have a filename (which is used by GA4 to determine if it's a file_download event)

### Testing
- Use this branch locally: `git pull origin google-tag-manager`.
- Download source data and the new standardized data.
- Go to the `Salary` property in Google Analytics
- In the Realtime Overview, make sure you see the different events in the `download_data_event` type. Apparently it takes some time for the events to show up in the Engagement section.
